### PR TITLE
fix: fixed avc latency, timeouts, proper shutdown and repeating frames bug

### DIFF
--- a/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
@@ -61,13 +61,12 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
                     "--fps" -> {
                         if (i + 1 < args.size) {
                             val parsedFps = args[i + 1].toIntOrNull()
-                            if (parsedFps == null) {
-                                throw IllegalArgumentException("Invalid fps value: ${args[i + 1]}. Must be an integer between $MIN_FPS and $MAX_FPS")
+                            fps = if (parsedFps != null && parsedFps >= MIN_FPS && parsedFps <= MAX_FPS) {
+                                parsedFps
+                            } else {
+                                Log.w(TAG, "Invalid fps value: ${args[i + 1]}. Using default: $DEFAULT_FPS")
+                                DEFAULT_FPS
                             }
-                            if (parsedFps < MIN_FPS || parsedFps > MAX_FPS) {
-                                throw IllegalArgumentException("fps value out of range: $parsedFps. Must be between $MIN_FPS and $MAX_FPS")
-                            }
-                            fps = parsedFps
                             i++
                         }
                     }
@@ -163,6 +162,8 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
             // Low latency settings
             setInteger(MediaFormat.KEY_LATENCY, 0)  // Request lowest latency
             setInteger(MediaFormat.KEY_PRIORITY, 0)  // Realtime priority
+            // Repeat previous frame after 100ms to keep stream alive when screen is static
+            setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 100_000L)  // 100ms in microseconds
         }
 
         Log.d(TAG, "MediaFormat created: $format")
@@ -206,7 +207,7 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
         Log.d(TAG, "AVC encoder started")
 
         val bufferInfo = MediaCodec.BufferInfo()
-        val timeout = 10000L  // 10ms timeout for lower latency
+        val timeout = -1L  // Block indefinitely until buffer is available
 
         // Get FileChannel for stdout to write directly from ByteBuffer (zero-copy)
         val stdoutChannel = FileOutputStream(FileDescriptor.out).channel

--- a/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
@@ -61,7 +61,7 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
                     "--fps" -> {
                         if (i + 1 < args.size) {
                             val parsedFps = args[i + 1].toIntOrNull()
-                            fps = if (parsedFps != null && parsedFps >= MIN_FPS && parsedFps <= MAX_FPS) {
+                            fps = if (parsedFps != null && parsedFps in MIN_FPS..MAX_FPS) {
                                 parsedFps
                             } else {
                                 Log.w(TAG, "Invalid fps value: ${args[i + 1]}. Using default: $DEFAULT_FPS")
@@ -100,6 +100,33 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
 
     private fun shutdown() {
         shutdownLatch.countDown()
+    }
+
+    private fun cleanupResources(
+        stdoutChannel: java.nio.channels.FileChannel?,
+        codec: MediaCodec?,
+        virtualDisplay: VirtualDisplay?
+    ) {
+        try {
+            stdoutChannel?.close()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error closing stdout channel", e)
+        }
+        try {
+            codec?.stop()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping codec", e)
+        }
+        try {
+            codec?.release()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error releasing codec", e)
+        }
+        try {
+            virtualDisplay?.release()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error releasing virtual display", e)
+        }
     }
 
     private fun streamAvcFrames() {
@@ -244,16 +271,8 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
                                 }
                             } catch (e: IOException) {
                                 // Pipe broken - client disconnected
-                                Log.d(TAG, "Output pipe broken, cleaning up")
-                                // Clean up resources before exiting
-                                try {
-                                    stdoutChannel.close()
-                                    codec.stop()
-                                    codec.release()
-                                    virtualDisplay.release()
-                                } catch (ex: Exception) {
-                                    Log.e(TAG, "Error during cleanup", ex)
-                                }
+                                Log.d(TAG, "Output pipe broken, cleaning up and exiting")
+                                cleanupResources(stdoutChannel, codec, virtualDisplay)
                                 exitProcess(0)
                             }
 
@@ -306,10 +325,7 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
             }
         } finally {
             Log.d(TAG, "Stopping AVC encoder")
-            stdoutChannel.close()
-            codec.stop()
-            codec.release()
-            virtualDisplay.release()
+            cleanupResources(stdoutChannel, codec, virtualDisplay)
         }
     }
 }

--- a/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
@@ -207,7 +207,7 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
         Log.d(TAG, "AVC encoder started")
 
         val bufferInfo = MediaCodec.BufferInfo()
-        val timeout = -1L  // Block indefinitely until buffer is available
+        val timeout = 100_000L  // 100ms timeout for responsive shutdown (matches REPEAT_FRAME_DELAY)
 
         // Get FileChannel for stdout to write directly from ByteBuffer (zero-copy)
         val stdoutChannel = FileOutputStream(FileDescriptor.out).channel
@@ -244,9 +244,17 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
                                 }
                             } catch (e: IOException) {
                                 // Pipe broken - client disconnected
-                                Log.d(TAG, "Output pipe broken, shutting down")
-                                shutdown()
-                                break
+                                Log.d(TAG, "Output pipe broken, cleaning up")
+                                // Clean up resources before exiting
+                                try {
+                                    stdoutChannel.close()
+                                    codec.stop()
+                                    codec.release()
+                                    virtualDisplay.release()
+                                } catch (ex: Exception) {
+                                    Log.e(TAG, "Error during cleanup", ex)
+                                }
+                                exitProcess(0)
                             }
 
                             // Log frame info


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FPS input now validates and falls back to a safe default instead of failing.
  * Frame-repeat added to improve stream stability when the screen is static.
  * Increased output buffer timeout to reduce spurious timeouts.
  * Improved shutdown behavior to ensure cleanup before exit and handle write failures gracefully.

* **Refactor**
  * Centralized resource cleanup to reliably close/release resources in all paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->