### PR TITLE
feat: add UI view tree dump via instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Note that the single quotes after `adb shell` are required if your text includes
 adb shell am instrument -w com.mobilenext.devicekit/.ViewTreeDump
 ```
 
-The XML hierarchy is returned inline in the `INSTRUMENTATION_STATUS: xml=` line of the output.
+The JSON hierarchy is returned inline in the `INSTRUMENTATION_STATUS: json=` line of the output.
 
 **Parameters:**
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ that is not possible through adb-shell alone.
 
 - Control clipboard content with support for utf8
 - Stream screen buffer as mjpeg (with scaling and quality parameters)
+- Dump UI view tree as XML (instrumentation-based, no accessibility service required)
 
 ## Installing
 
@@ -52,12 +53,30 @@ Since **devicekit** cannot force a keypress, use `adb shell input keyevent KEYCO
 
 Note that the single quotes after `adb shell` are required if your text includes spaces. The base64 encoding allows you to safely transfer whatever utf8 you wish to paste.
 
+### Dumping the UI View Tree
+
+```bash
+adb shell am instrument -w com.mobilenext.devicekit/.ViewTreeDump
+```
+
+The XML hierarchy is returned inline in the `INSTRUMENTATION_STATUS: xml=` line of the output.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `waitUntilIdle` | int (ms) | Wait up to N ms for the UI to become idle before dumping. Useful after a navigation or transition. Default: 0 (no wait). |
+
+Example with idle wait:
+```bash
+adb shell am instrument -w -e waitUntilIdle 2000 com.mobilenext.devicekit/.ViewTreeDump
+```
+
 ## Installation
 
-1. Build the APK using Android Studio or Gradle
-2. Install on your device: `adb install app/build/outputs/apk/debug/app-debug.apk`
-3. Launch the app to verify it's running
-4. Use the ADB commands above to set clipboard content
+1. Build the APKs using Android Studio or Gradle
+2. Install: `adb install app/build/outputs/apk/debug/app-debug.apk`
+3. Use the ADB commands above
 
 ## Debugging
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,10 +47,13 @@ android {
 dependencies {
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.tracing)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.androidx.uiautomator) {
+        exclude(group = "junit", module = "junit")
+    }
     testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,6 +14,13 @@
 # Keep all classes in our package unobfuscated
 -keep class com.mobilenext.devicekit.** { *; }
 
+# Keep tracing and test runner classes
+-keep class androidx.tracing.Trace { *; }
+-keep class androidx.test.** { *; }
+
+# Keep Kotlin stdlib needed by the test runner
+-keep class kotlin.** { *; }
+
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
 # class:

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,12 +14,6 @@
 # Keep all classes in our package unobfuscated
 -keep class com.mobilenext.devicekit.** { *; }
 
-# Keep tracing and test runner classes
--keep class androidx.tracing.Trace { *; }
--keep class androidx.test.** { *; }
-
-# Keep Kotlin stdlib needed by the test runner
--keep class kotlin.** { *; }
 
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <!-- Permission to access clipboard -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
+    <instrumentation
+        android:name=".ViewTreeDump"
+        android:targetPackage="com.mobilenext.devicekit" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
@@ -10,9 +10,8 @@ import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import android.view.accessibility.AccessibilityWindowInfo
 import androidx.test.uiautomator.UiDevice
-import org.xmlpull.v1.XmlPullParserFactory
-import org.xmlpull.v1.XmlSerializer
-import java.io.StringWriter
+import org.json.JSONArray
+import org.json.JSONObject
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -52,64 +51,61 @@ class ViewTreeDump : Instrumentation() {
             }
 
             Log.i(TAG, "windows=${windows.size} roots=${roots.size}")
-            val xml = serializeToXml(roots)
+            val json = serializeToJson(roots)
             roots.forEach { it.recycle() }
-            Log.i(TAG, "XML size: ${xml.length} chars")
+            Log.i(TAG, "JSON size: ${json.length} chars")
 
             val result = Bundle()
-            result.putString("xml", xml)
+            result.putString("json", json)
             sendStatus(0, result)
             finish(Activity.RESULT_OK, Bundle())
         }.start()
     }
 
-    private fun serializeToXml(roots: List<AccessibilityNodeInfo>): String {
-        val writer = StringWriter()
-        val serializer: XmlSerializer = XmlPullParserFactory.newInstance().newSerializer()
-        serializer.setOutput(writer)
-        serializer.startDocument("UTF-8", true)
-        serializer.startTag("", "hierarchy")
+    private fun serializeToJson(roots: List<AccessibilityNodeInfo>): String {
+        val array = JSONArray()
         for (root in roots) {
-            serializeNode(serializer, root, 0)
+            array.put(nodeToJson(root, 0))
         }
-        serializer.endTag("", "hierarchy")
-        serializer.endDocument()
-        return writer.toString()
+        return JSONObject().put("hierarchy", array).toString()
     }
 
-    private fun serializeNode(serializer: XmlSerializer, node: AccessibilityNodeInfo, index: Int) {
-        val className = node.className?.toString() ?: "unknown"
-        val tag = className.substringAfterLast('.')
-
-        serializer.startTag("", tag)
-        serializer.attribute("", "index", index.toString())
-        serializer.attribute("", "class", className)
-        serializer.attribute("", "package", node.packageName?.toString() ?: "")
-        serializer.attribute("", "text", node.text?.toString() ?: "")
-        serializer.attribute("", "content-desc", node.contentDescription?.toString() ?: "")
-        serializer.attribute("", "resource-id", node.viewIdResourceName ?: "")
-        serializer.attribute("", "checkable", node.isCheckable.toString())
-        serializer.attribute("", "checked", node.isChecked.toString())
-        serializer.attribute("", "clickable", node.isClickable.toString())
-        serializer.attribute("", "enabled", node.isEnabled.toString())
-        serializer.attribute("", "focusable", node.isFocusable.toString())
-        serializer.attribute("", "focused", node.isFocused.toString())
-        serializer.attribute("", "scrollable", node.isScrollable.toString())
-        serializer.attribute("", "long-clickable", node.isLongClickable.toString())
-        serializer.attribute("", "password", node.isPassword.toString())
-        serializer.attribute("", "selected", node.isSelected.toString())
-        serializer.attribute("", "visible", node.isVisibleToUser.toString())
-
+    private fun nodeToJson(node: AccessibilityNodeInfo, index: Int): JSONObject {
         val bounds = Rect()
         node.getBoundsInScreen(bounds)
-        serializer.attribute("", "bounds", "[${bounds.left},${bounds.top}][${bounds.right},${bounds.bottom}]")
 
+        val obj = JSONObject()
+            .put("index", index)
+            .put("class", node.className?.toString() ?: "")
+            .put("package", node.packageName?.toString() ?: "")
+            .put("text", node.text?.toString() ?: "")
+            .put("content-desc", node.contentDescription?.toString() ?: "")
+            .put("resource-id", node.viewIdResourceName ?: "")
+            .put("checkable", node.isCheckable)
+            .put("checked", node.isChecked)
+            .put("clickable", node.isClickable)
+            .put("enabled", node.isEnabled)
+            .put("focusable", node.isFocusable)
+            .put("focused", node.isFocused)
+            .put("scrollable", node.isScrollable)
+            .put("long-clickable", node.isLongClickable)
+            .put("password", node.isPassword)
+            .put("selected", node.isSelected)
+            .put("visible", node.isVisibleToUser)
+            .put("bounds", JSONObject()
+                .put("left", bounds.left).put("top", bounds.top)
+                .put("right", bounds.right).put("bottom", bounds.bottom))
+
+        val children = JSONArray()
         for (i in 0 until node.childCount) {
             val child = node.getChild(i) ?: continue
-            serializeNode(serializer, child, i)
+            children.put(nodeToJson(child, i))
             child.recycle()
         }
+        if (children.length() > 0) {
+            obj.put("children", children)
+        }
 
-        serializer.endTag("", tag)
+        return obj
     }
 }

--- a/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
@@ -1,0 +1,115 @@
+package com.mobilenext.devicekit
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.app.Activity
+import android.app.Instrumentation
+import android.graphics.Rect
+import android.os.Bundle
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import androidx.test.uiautomator.UiDevice
+import org.xmlpull.v1.XmlPullParserFactory
+import org.xmlpull.v1.XmlSerializer
+import java.io.StringWriter
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class ViewTreeDump : Instrumentation() {
+
+    companion object {
+        const val TAG = "ViewTreeDump"
+    }
+
+    override fun onCreate(arguments: Bundle?) {
+        super.onCreate(arguments)
+        val waitUntilIdle = arguments?.getString("waitUntilIdle")?.toLongOrNull() ?: 0L
+        Thread {
+            val uiAutomation = uiAutomation
+
+            val latch = CountDownLatch(1)
+            uiAutomation.setOnAccessibilityEventListener { latch.countDown() }
+            uiAutomation.serviceInfo = AccessibilityServiceInfo().apply {
+                eventTypes = AccessibilityEvent.TYPES_ALL_MASK
+                feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+                flags = AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS or
+                        AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or
+                        AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+            }
+            latch.await(2, TimeUnit.SECONDS)
+            uiAutomation.setOnAccessibilityEventListener(null)
+
+            if (waitUntilIdle > 0) {
+                UiDevice.getInstance(this).waitForIdle(waitUntilIdle)
+            }
+
+            val windows: List<AccessibilityWindowInfo> = uiAutomation.windows
+            val roots: List<AccessibilityNodeInfo> = if (windows.isNotEmpty()) {
+                windows.mapNotNull { it.root }
+            } else {
+                listOfNotNull(uiAutomation.rootInActiveWindow)
+            }
+
+            Log.i(TAG, "windows=${windows.size} roots=${roots.size}")
+            val xml = serializeToXml(roots)
+            roots.forEach { it.recycle() }
+            Log.i(TAG, "XML size: ${xml.length} chars")
+
+            val result = Bundle()
+            result.putString("xml", xml)
+            sendStatus(0, result)
+            finish(Activity.RESULT_OK, Bundle())
+        }.start()
+    }
+
+    private fun serializeToXml(roots: List<AccessibilityNodeInfo>): String {
+        val writer = StringWriter()
+        val serializer: XmlSerializer = XmlPullParserFactory.newInstance().newSerializer()
+        serializer.setOutput(writer)
+        serializer.startDocument("UTF-8", true)
+        serializer.startTag("", "hierarchy")
+        for (root in roots) {
+            serializeNode(serializer, root, 0)
+        }
+        serializer.endTag("", "hierarchy")
+        serializer.endDocument()
+        return writer.toString()
+    }
+
+    private fun serializeNode(serializer: XmlSerializer, node: AccessibilityNodeInfo, index: Int) {
+        val className = node.className?.toString() ?: "unknown"
+        val tag = className.substringAfterLast('.')
+
+        serializer.startTag("", tag)
+        serializer.attribute("", "index", index.toString())
+        serializer.attribute("", "class", className)
+        serializer.attribute("", "package", node.packageName?.toString() ?: "")
+        serializer.attribute("", "text", node.text?.toString() ?: "")
+        serializer.attribute("", "content-desc", node.contentDescription?.toString() ?: "")
+        serializer.attribute("", "resource-id", node.viewIdResourceName ?: "")
+        serializer.attribute("", "checkable", node.isCheckable.toString())
+        serializer.attribute("", "checked", node.isChecked.toString())
+        serializer.attribute("", "clickable", node.isClickable.toString())
+        serializer.attribute("", "enabled", node.isEnabled.toString())
+        serializer.attribute("", "focusable", node.isFocusable.toString())
+        serializer.attribute("", "focused", node.isFocused.toString())
+        serializer.attribute("", "scrollable", node.isScrollable.toString())
+        serializer.attribute("", "long-clickable", node.isLongClickable.toString())
+        serializer.attribute("", "password", node.isPassword.toString())
+        serializer.attribute("", "selected", node.isSelected.toString())
+        serializer.attribute("", "visible", node.isVisibleToUser.toString())
+
+        val bounds = Rect()
+        node.getBoundsInScreen(bounds)
+        serializer.attribute("", "bounds", "[${bounds.left},${bounds.top}][${bounds.right},${bounds.bottom}]")
+
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i) ?: continue
+            serializeNode(serializer, child, i)
+            child.recycle()
+        }
+
+        serializer.endTag("", tag)
+    }
+}

--- a/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
@@ -26,39 +26,49 @@ class ViewTreeDump : Instrumentation() {
         val waitUntilIdle = arguments?.getString("waitUntilIdle")?.toLongOrNull() ?: 0L
         Thread {
             val uiAutomation = uiAutomation
+            var roots: List<AccessibilityNodeInfo> = emptyList()
+            try {
+                val latch = CountDownLatch(1)
+                uiAutomation.setOnAccessibilityEventListener { latch.countDown() }
+                uiAutomation.serviceInfo = AccessibilityServiceInfo().apply {
+                    eventTypes = AccessibilityEvent.TYPES_ALL_MASK
+                    feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+                    flags = AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS or
+                            AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or
+                            AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+                }
+                latch.await(2, TimeUnit.SECONDS)
 
-            val latch = CountDownLatch(1)
-            uiAutomation.setOnAccessibilityEventListener { latch.countDown() }
-            uiAutomation.serviceInfo = AccessibilityServiceInfo().apply {
-                eventTypes = AccessibilityEvent.TYPES_ALL_MASK
-                feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
-                flags = AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS or
-                        AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or
-                        AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+                if (waitUntilIdle > 0) {
+                    UiDevice.getInstance(this).waitForIdle(waitUntilIdle)
+                }
+
+                val windows: List<AccessibilityWindowInfo> = uiAutomation.windows
+                roots = if (windows.isNotEmpty()) {
+                    windows.mapNotNull { it.root }
+                } else {
+                    listOfNotNull(uiAutomation.rootInActiveWindow)
+                }
+                windows.forEach { it.recycle() }
+
+                Log.i(TAG, "windows=${windows.size} roots=${roots.size}")
+                val json = serializeToJson(roots)
+                Log.i(TAG, "JSON size: ${json.length} chars")
+
+                val result = Bundle()
+                result.putString("json", json)
+                sendStatus(0, result)
+                finish(Activity.RESULT_OK, Bundle())
+            } catch (t: Throwable) {
+                Log.e(TAG, "dump failed", t)
+                val error = Bundle()
+                error.putString("error", t.message ?: t.javaClass.simpleName)
+                sendStatus(1, error)
+                finish(Activity.RESULT_CANCELED, error)
+            } finally {
+                uiAutomation.setOnAccessibilityEventListener(null)
+                roots.forEach { it.recycle() }
             }
-            latch.await(2, TimeUnit.SECONDS)
-            uiAutomation.setOnAccessibilityEventListener(null)
-
-            if (waitUntilIdle > 0) {
-                UiDevice.getInstance(this).waitForIdle(waitUntilIdle)
-            }
-
-            val windows: List<AccessibilityWindowInfo> = uiAutomation.windows
-            val roots: List<AccessibilityNodeInfo> = if (windows.isNotEmpty()) {
-                windows.mapNotNull { it.root }
-            } else {
-                listOfNotNull(uiAutomation.rootInActiveWindow)
-            }
-
-            Log.i(TAG, "windows=${windows.size} roots=${roots.size}")
-            val json = serializeToJson(roots)
-            roots.forEach { it.recycle() }
-            Log.i(TAG, "JSON size: ${json.length} chars")
-
-            val result = Bundle()
-            result.putString("json", json)
-            sendStatus(0, result)
-            finish(Activity.RESULT_OK, Bundle())
         }.start()
     }
 

--- a/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
@@ -92,9 +92,9 @@ class ViewTreeDump : Instrumentation() {
             .put("password", node.isPassword)
             .put("selected", node.isSelected)
             .put("visible", node.isVisibleToUser)
-            .put("bounds", JSONObject()
-                .put("left", bounds.left).put("top", bounds.top)
-                .put("right", bounds.right).put("bottom", bounds.bottom))
+            .put("rect", JSONObject()
+                .put("x", bounds.left).put("y", bounds.top)
+                .put("width", bounds.right - bounds.left).put("height", bounds.bottom - bounds.top))
 
         val children = JSONArray()
         for (i in 0 until node.childCount) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
+uiautomator = "2.3.0"
+tracing = "1.3.0-alpha02"
 appcompat = "1.6.1"
 material = "1.10.0"
 
@@ -14,6 +16,8 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
+androidx-tracing = { group = "androidx.tracing", name = "tracing", version.ref = "tracing" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 


### PR DESCRIPTION
## Summary

- Adds `ViewTreeDump`, a custom `Instrumentation` subclass that dumps the full UI hierarchy as XML using `UiAutomation`
- No accessibility service grant required — works via `am instrument` like UIAutomator/Appium
- Single APK, no separate test APK needed
- Supports `waitUntilIdle` parameter for post-transition dumps

## Usage

```bash
# Dump current UI tree
adb shell am instrument -w com.mobilenext.devicekit/.ViewTreeDump

# Wait up to 2s for idle first (useful after navigation)
adb shell am instrument -w -e waitUntilIdle 2000 com.mobilenext.devicekit/.ViewTreeDump
```

XML is returned inline in `INSTRUMENTATION_STATUS: xml=` output.

## Test plan

- [x] Install APK and run dump command, verify XML output appears inline
- [x] Test with `waitUntilIdle` parameter
- [x] Verify clipboard receivers still work (`devicekit.clipboard.set` / `devicekit.clipboard.clear`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ViewTreeDump`, an `Instrumentation` that dumps the current UI view hierarchy as JSON via `UiAutomation`, runnable with `adb` without an accessibility service or a test APK. Also tightens ProGuard to halve APK size and improves reliability with error handling and window recycling.

- **New Features**
  - `com.mobilenext.devicekit/.ViewTreeDump` outputs the full UI tree as inline `INSTRUMENTATION_STATUS: json=...`.
  - Node geometry uses `rect {x,y,width,height}` instead of `bounds`.
  - Supports `waitUntilIdle` (ms) to wait for idle before dumping.
  - Adds manifest `<instrumentation>` entry.

- **Dependencies**
  - Added `androidx.test.uiautomator` (excluding `junit`).
  - Added `androidx.tracing`.
  - Removed `androidx.test.ext:junit` from `androidTestImplementation`.

<sup>Written for commit 906cfb0bdaed46d0a9a6a5265877b0b43d257959. Summary will update on new commits. <a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/14?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

