### PR TITLE
feat: version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.0](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.0) (2026-05-17)
+
+* Added UI view tree dump service via instrumentation, as a workaround for UIAutomator2 timeouts during animations ([#14](https://github.com/mobile-next/devicekit-android/pull/14))
+* Reduced APK size by ~50% by removing over-broad ProGuard keep rules ([#14](https://github.com/mobile-next/devicekit-android/pull/14))
+
 ## [1.1.5](https://github.com/mobile-next/mobile-mcp/releases/tag/1.1.5) (2025-12-07)
 
 * Fixed AVC encoder latency issues with reduced timeout

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.mobilenext.devicekit"
         minSdk = 29
         targetSdk = 35
-        versionCode = 2
-        versionName = "1.1.2"
+        versionCode = 3
+        versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary

- Updated CHANGELOG with 1.2.0 entries
- Bumped versionCode to 3, versionName to 1.2.0

## Changes since 1.1.5

- Added UI view tree dump service via instrumentation, as a workaround for UIAutomator2 timeouts during animations ([#14](https://github.com/mobile-next/devicekit-android/pull/14))
- Reduced APK size by ~50% by removing over-broad ProGuard keep rules ([#14](https://github.com/mobile-next/devicekit-android/pull/14))

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.2.0 adds an instrumentation-based UI view tree dump to work around UIAutomator2 timeouts during animations and cuts the APK size by ~50%. Also bumps versionCode to 3, sets versionName to 1.2.0, and updates the changelog.

<sup>Written for commit ac9b47064b4f21d9c9fe3c0803a63ed13f964c38. Summary will update on new commits. <a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/15?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

