### PR TITLE
fix: grant contents:write permission to build job for release uploads

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: lint-and-detekt
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code
@@ -68,8 +70,6 @@ jobs:
     - name: Upload to GitHub Release
       if: github.ref_type == 'tag'
       uses: softprops/action-gh-release@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASES_TOKEN }}
       with:
         name: Version ${{ github.ref_name }}
         files: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix release uploads by granting `contents: write` to the `build` job and using the default `GITHUB_TOKEN`. Tagged builds can now publish assets to GitHub Releases without a custom token.

- **Bug Fixes**
  - Add job-level `permissions: contents: write`.
  - Remove custom `RELEASES_TOKEN` override; rely on `softprops/action-gh-release@v2` with the job `GITHUB_TOKEN`.

<sup>Written for commit b2dfed9004284594c4479cc993e444d33e289268. Summary will update on new commits. <a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/16?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

