### PR TITLE
License under FSL-1.1-Apache-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,45 @@
+Functional Source License, Version 1.1, ALv2 Future License
+
+Copyright 2025-2026 Mobile Next HQ, Inc.
+
+Terms and Conditions
+
+Licensor ("We")
+The party offering the Software under these Terms and Conditions.
+
+The Software
+The "Software" is each version of the software that we make available under these Terms and Conditions, as indicated by our inclusion of these Terms and Conditions with the Software.
+
+License Grant
+Subject to your compliance with this License Grant and the Patents, Redistribution and Trademark clauses below, we hereby grant you the right to use, copy, modify, create derivative works, publicly perform, publicly display and redistribute the Software for any Permitted Purpose identified below.
+
+Permitted Purpose
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use means making the Software available to others in a commercial product or service that:
+
+1. substitutes for the Software;
+2. substitutes for any other product or service we offer using the Software that exists as of the date we make the Software available; or
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using the Software in accordance with these Terms and Conditions.
+
+Patents
+To the extent your use for a Permitted Purpose would necessarily infringe our patents, the license grant above includes a license under our patents. If you make a claim against any party that the Software infringes or contributes to the infringement of any patent, then your patent license to the Software ends immediately.
+
+Redistribution
+The Terms and Conditions apply to all copies, modifications and derivatives of the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software, you must include a copy of or a link to these Terms and Conditions and not remove any copyright notices provided in or with the Software.
+
+Disclaimer
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+Trademarks
+Except for displaying the License Details and identifying us as the origin of the Software, you have no right under these Terms and Conditions to use our trademarks, trade names, service marks or product names.
+
+Grant of Future License
+An additional Apache License, Version 2.0 becomes effective on the second anniversary of the Software's initial availability. After that date, users may alternatively use the Software under the Apache License, Version 2.0.


### PR DESCRIPTION
## Summary
- Add Functional Source License 1.1 (ALv2 future license)
- Copyright 2025-2026 Mobile Next HQ, Inc.
- Converts to Apache 2.0 on the second anniversary of initial availability
