### PR TITLE
feat: devicekit http server for faster actions without use of process…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,46 @@ Example with idle wait:
 adb shell am instrument -w -e waitUntilIdle 2000 com.mobilenext.devicekit/.ViewTreeDump
 ```
 
+### Using the HTTP Server
+
+For repeated queries, the one-shot `am instrument` invocation above pays the instrumentation startup cost on every call. The HTTP server starts once and stays resident, answering requests over a persistent connection.
+
+Start the server:
+
+```bash
+adb shell am instrument -w com.mobilenext.devicekit/.DeviceKitServer
+```
+
+It listens on the abstract socket `localabstract:devicekit` and keeps running until the instrumentation is stopped. Leave this command running (or background it).
+
+Forward a local TCP port to the socket:
+
+```bash
+adb forward tcp:8080 localabstract:devicekit
+```
+
+Fetch the UI tree with a JSON-RPC request over `curl`:
+
+```bash
+curl -s http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"device.dump.ui","params":{}}'
+```
+
+The response is a JSON-RPC envelope whose `result` holds the `hierarchy` tree. The optional `waitUntilIdle` parameter (milliseconds) behaves as above:
+
+```bash
+curl -s http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"device.dump.ui","params":{"waitUntilIdle":2000}}'
+```
+
+Remove the forward when done:
+
+```bash
+adb forward --remove tcp:8080
+```
+
 ## Installation
 
 1. Build the APKs using Android Studio or Gradle

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
         android:name=".ViewTreeDump"
         android:targetPackage="com.mobilenext.devicekit" />
 
+    <instrumentation
+        android:name=".DeviceKitServer"
+        android:targetPackage="com.mobilenext.devicekit" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
@@ -1,0 +1,136 @@
+package com.mobilenext.devicekit
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.app.Activity
+import android.app.Instrumentation
+import android.app.UiAutomation
+import android.net.LocalServerSocket
+import android.net.LocalSocket
+import android.os.Bundle
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class DeviceKitServer : Instrumentation() {
+
+    companion object {
+        private const val TAG = "DeviceKitServer"
+        private const val SOCKET_NAME = "devicekit"
+    }
+
+    override fun onCreate(arguments: Bundle?) {
+        super.onCreate(arguments)
+        Thread { runServer() }.start()
+    }
+
+    private fun runServer() {
+        val uiAutomation = uiAutomation
+        try {
+            connectUiAutomation(uiAutomation)
+
+            val serverSocket = LocalServerSocket(SOCKET_NAME)
+            Log.i(TAG, "Listening on localabstract:$SOCKET_NAME")
+
+            while (true) {
+                val conn = serverSocket.accept()
+                try {
+                    handleConnection(conn, uiAutomation)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error handling connection", e)
+                } finally {
+                    conn.close()
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Server error", e)
+            val error = Bundle()
+            error.putString("error", e.message ?: e.javaClass.simpleName)
+            finish(Activity.RESULT_CANCELED, error)
+        }
+    }
+
+    private fun connectUiAutomation(uiAutomation: UiAutomation) {
+        val latch = CountDownLatch(1)
+        uiAutomation.setOnAccessibilityEventListener { latch.countDown() }
+        uiAutomation.serviceInfo = AccessibilityServiceInfo().apply {
+            eventTypes = AccessibilityEvent.TYPES_ALL_MASK
+            feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+            flags = AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS or
+                    AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or
+                    AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
+        }
+        latch.await(2, TimeUnit.SECONDS)
+        uiAutomation.setOnAccessibilityEventListener(null)
+    }
+
+    private fun handleConnection(conn: LocalSocket, uiAutomation: UiAutomation) {
+        val reader = BufferedReader(InputStreamReader(conn.inputStream, Charsets.ISO_8859_1))
+
+        reader.readLine() ?: return
+
+        var contentLength = 0
+        var line = reader.readLine()
+        while (line != null && line.isNotEmpty()) {
+            if (line.lowercase().startsWith("content-length:")) {
+                contentLength = line.substring(15).trim().toIntOrNull() ?: 0
+            }
+            line = reader.readLine()
+        }
+
+        val bodyChars = CharArray(contentLength)
+        var offset = 0
+        while (offset < contentLength) {
+            val n = reader.read(bodyChars, offset, contentLength - offset)
+            if (n == -1) break
+            offset += n
+        }
+        val body = String(bodyChars)
+
+        val responseJson = handleJsonRpc(body, uiAutomation)
+        val responseBytes = responseJson.toByteArray(Charsets.UTF_8)
+
+        val httpResponse = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${responseBytes.size}\r\nConnection: close\r\n\r\n"
+        conn.outputStream.write(httpResponse.toByteArray(Charsets.UTF_8))
+        conn.outputStream.write(responseBytes)
+        conn.outputStream.flush()
+    }
+
+    private fun handleJsonRpc(body: String, uiAutomation: UiAutomation): String {
+        return try {
+            val request = JSONObject(body)
+            val id = request.opt("id")
+            val method = request.optString("method")
+            val params = request.optJSONObject("params")
+
+            when (method) {
+                "device.dump.ui" -> {
+                    val waitUntilIdle = params?.optLong("waitUntilIdle") ?: 0L
+                    val hierarchy = JSONObject(UiTreeSerializer.dump(uiAutomation, this, waitUntilIdle))
+                    jsonRpcResult(id, hierarchy)
+                }
+                else -> jsonRpcError(id, -32601, "Method not found: $method")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "JSON-RPC error", e)
+            jsonRpcError(null, -32700, "Parse error: ${e.message}")
+        }
+    }
+
+    private fun jsonRpcResult(id: Any?, result: Any): String =
+        JSONObject()
+            .put("jsonrpc", "2.0")
+            .put("id", id ?: JSONObject.NULL)
+            .put("result", result)
+            .toString()
+
+    private fun jsonRpcError(id: Any?, code: Int, message: String): String =
+        JSONObject()
+            .put("jsonrpc", "2.0")
+            .put("id", id ?: JSONObject.NULL)
+            .put("error", JSONObject().put("code", code).put("message", message))
+            .toString()
+}

--- a/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
@@ -20,6 +20,13 @@ class DeviceKitServer : Instrumentation() {
     companion object {
         private const val TAG = "DeviceKitServer"
         private const val SOCKET_NAME = "devicekit"
+
+        // JSON-RPC 2.0 protocol (https://www.jsonrpc.org/specification)
+        private const val JSONRPC_VERSION = "2.0"
+
+        // JSON-RPC 2.0 standard error codes
+        private const val JSONRPC_PARSE_ERROR = -32700
+        private const val JSONRPC_METHOD_NOT_FOUND = -32601
     }
 
     override fun onCreate(arguments: Bundle?) {
@@ -112,24 +119,24 @@ class DeviceKitServer : Instrumentation() {
                     val hierarchy = JSONObject(UiTreeSerializer.dump(uiAutomation, this, waitUntilIdle))
                     jsonRpcResult(id, hierarchy)
                 }
-                else -> jsonRpcError(id, -32601, "Method not found: $method")
+                else -> jsonRpcError(id, JSONRPC_METHOD_NOT_FOUND, "Method not found: $method")
             }
         } catch (e: Exception) {
             Log.e(TAG, "JSON-RPC error", e)
-            jsonRpcError(null, -32700, "Parse error: ${e.message}")
+            jsonRpcError(null, JSONRPC_PARSE_ERROR, "Parse error: ${e.message}")
         }
     }
 
     private fun jsonRpcResult(id: Any?, result: Any): String =
         JSONObject()
-            .put("jsonrpc", "2.0")
+            .put("jsonrpc", JSONRPC_VERSION)
             .put("id", id ?: JSONObject.NULL)
             .put("result", result)
             .toString()
 
     private fun jsonRpcError(id: Any?, code: Int, message: String): String =
         JSONObject()
-            .put("jsonrpc", "2.0")
+            .put("jsonrpc", JSONRPC_VERSION)
             .put("id", id ?: JSONObject.NULL)
             .put("error", JSONObject().put("code", code).put("message", message))
             .toString()

--- a/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
@@ -88,7 +88,7 @@ class DeviceKitServer : Instrumentation() {
             if (n == -1) break
             offset += n
         }
-        val body = String(bodyChars)
+        val body = String(bodyChars, 0, offset)
 
         val responseJson = handleJsonRpc(body, uiAutomation)
         val responseBytes = responseJson.toByteArray(Charsets.UTF_8)

--- a/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
@@ -27,6 +27,7 @@ class DeviceKitServer : Instrumentation() {
         // JSON-RPC 2.0 standard error codes
         private const val JSONRPC_PARSE_ERROR = -32700
         private const val JSONRPC_METHOD_NOT_FOUND = -32601
+        private const val JSONRPC_INTERNAL_ERROR = -32603
     }
 
     override fun onCreate(arguments: Bundle?) {
@@ -36,10 +37,11 @@ class DeviceKitServer : Instrumentation() {
 
     private fun runServer() {
         val uiAutomation = uiAutomation
+        var serverSocket: LocalServerSocket? = null
         try {
             connectUiAutomation(uiAutomation)
 
-            val serverSocket = LocalServerSocket(SOCKET_NAME)
+            serverSocket = LocalServerSocket(SOCKET_NAME)
             Log.i(TAG, "Listening on localabstract:$SOCKET_NAME")
 
             while (true) {
@@ -57,6 +59,8 @@ class DeviceKitServer : Instrumentation() {
             val error = Bundle()
             error.putString("error", e.message ?: e.javaClass.simpleName)
             finish(Activity.RESULT_CANCELED, error)
+        } finally {
+            serverSocket?.close()
         }
     }
 
@@ -107,9 +111,16 @@ class DeviceKitServer : Instrumentation() {
     }
 
     private fun handleJsonRpc(body: String, uiAutomation: UiAutomation): String {
+        val request: JSONObject
+        try {
+            request = JSONObject(body)
+        } catch (e: Exception) {
+            Log.e(TAG, "JSON parse error", e)
+            return jsonRpcError(null, JSONRPC_PARSE_ERROR, "Parse error: ${e.message}")
+        }
+
+        val id = request.opt("id")
         return try {
-            val request = JSONObject(body)
-            val id = request.opt("id")
             val method = request.optString("method")
             val params = request.optJSONObject("params")
 
@@ -122,8 +133,8 @@ class DeviceKitServer : Instrumentation() {
                 else -> jsonRpcError(id, JSONRPC_METHOD_NOT_FOUND, "Method not found: $method")
             }
         } catch (e: Exception) {
-            Log.e(TAG, "JSON-RPC error", e)
-            jsonRpcError(null, JSONRPC_PARSE_ERROR, "Parse error: ${e.message}")
+            Log.e(TAG, "Internal error", e)
+            jsonRpcError(id, JSONRPC_INTERNAL_ERROR, "Internal error: ${e.message}")
         }
     }
 

--- a/app/src/main/java/com/mobilenext/devicekit/UiTreeSerializer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/UiTreeSerializer.kt
@@ -17,12 +17,17 @@ object UiTreeSerializer {
         }
 
         val windows: List<AccessibilityWindowInfo> = uiAutomation.windows
-        val roots = if (windows.isNotEmpty()) {
-            windows.mapNotNull { it.root }
+        val windowRoots = windows.mapNotNull { it.root }
+        windows.forEach { it.recycle() }
+
+        // Windows can be present yet expose null roots (not queryable at the
+        // moment of the dump), which would otherwise yield an empty hierarchy.
+        // Fall back to the active window's root in that case.
+        val roots = if (windowRoots.isNotEmpty()) {
+            windowRoots
         } else {
             listOfNotNull(uiAutomation.rootInActiveWindow)
         }
-        windows.forEach { it.recycle() }
 
         try {
             return serialize(roots)
@@ -78,8 +83,11 @@ object UiTreeSerializer {
         val children = JSONArray()
         for (i in 0 until node.childCount) {
             val child = node.getChild(i) ?: continue
-            children.put(nodeToJson(child, i))
-            child.recycle()
+            try {
+                children.put(nodeToJson(child, i))
+            } finally {
+                child.recycle()
+            }
         }
         if (children.length() > 0) {
             obj.put("children", children)

--- a/app/src/main/java/com/mobilenext/devicekit/UiTreeSerializer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/UiTreeSerializer.kt
@@ -1,0 +1,90 @@
+package com.mobilenext.devicekit
+
+import android.app.Instrumentation
+import android.app.UiAutomation
+import android.graphics.Rect
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import androidx.test.uiautomator.UiDevice
+import org.json.JSONArray
+import org.json.JSONObject
+
+object UiTreeSerializer {
+
+    fun dump(uiAutomation: UiAutomation, instrumentation: Instrumentation? = null, waitUntilIdle: Long = 0L): String {
+        if (waitUntilIdle > 0 && instrumentation != null) {
+            UiDevice.getInstance(instrumentation).waitForIdle(waitUntilIdle)
+        }
+
+        val windows: List<AccessibilityWindowInfo> = uiAutomation.windows
+        val roots = if (windows.isNotEmpty()) {
+            windows.mapNotNull { it.root }
+        } else {
+            listOfNotNull(uiAutomation.rootInActiveWindow)
+        }
+        windows.forEach { it.recycle() }
+
+        try {
+            return serialize(roots)
+        } finally {
+            roots.forEach { it.recycle() }
+        }
+    }
+
+    private fun serialize(roots: List<AccessibilityNodeInfo>): String {
+        val array = JSONArray()
+        for (root in roots) {
+            array.put(nodeToJson(root, 0))
+        }
+        return JSONObject().put("hierarchy", array).toString()
+    }
+
+    private fun nodeToJson(node: AccessibilityNodeInfo, index: Int): JSONObject {
+        val bounds = Rect()
+        node.getBoundsInScreen(bounds)
+
+        // When a field is empty, AccessibilityNodeInfo.text returns the hint.
+        // Separate the two: report empty text for an empty field and expose the
+        // hint as its own attribute (mapped to `placeholder` downstream).
+        val rawText = node.text?.toString() ?: ""
+        val hintText = node.hintText?.toString() ?: ""
+        val showingHint = node.isShowingHintText
+        val text = if (showingHint) "" else rawText
+        val hint = if (hintText.isNotEmpty()) hintText else if (showingHint) rawText else ""
+
+        val obj = JSONObject()
+            .put("index", index)
+            .put("class", node.className?.toString() ?: "")
+            .put("package", node.packageName?.toString() ?: "")
+            .put("text", text)
+            .put("hint", hint)
+            .put("content-desc", node.contentDescription?.toString() ?: "")
+            .put("resource-id", node.viewIdResourceName ?: "")
+            .put("checkable", node.isCheckable)
+            .put("checked", node.isChecked)
+            .put("clickable", node.isClickable)
+            .put("enabled", node.isEnabled)
+            .put("focusable", node.isFocusable)
+            .put("focused", node.isFocused)
+            .put("scrollable", node.isScrollable)
+            .put("long-clickable", node.isLongClickable)
+            .put("password", node.isPassword)
+            .put("selected", node.isSelected)
+            .put("visible", node.isVisibleToUser)
+            .put("rect", JSONObject()
+                .put("x", bounds.left).put("y", bounds.top)
+                .put("width", bounds.right - bounds.left).put("height", bounds.bottom - bounds.top))
+
+        val children = JSONArray()
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i) ?: continue
+            children.put(nodeToJson(child, i))
+            child.recycle()
+        }
+        if (children.length() > 0) {
+            obj.put("children", children)
+        }
+
+        return obj
+    }
+}

--- a/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/ViewTreeDump.kt
@@ -3,15 +3,9 @@ package com.mobilenext.devicekit
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.app.Activity
 import android.app.Instrumentation
-import android.graphics.Rect
 import android.os.Bundle
 import android.util.Log
 import android.view.accessibility.AccessibilityEvent
-import android.view.accessibility.AccessibilityNodeInfo
-import android.view.accessibility.AccessibilityWindowInfo
-import androidx.test.uiautomator.UiDevice
-import org.json.JSONArray
-import org.json.JSONObject
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -26,7 +20,6 @@ class ViewTreeDump : Instrumentation() {
         val waitUntilIdle = arguments?.getString("waitUntilIdle")?.toLongOrNull() ?: 0L
         Thread {
             val uiAutomation = uiAutomation
-            var roots: List<AccessibilityNodeInfo> = emptyList()
             try {
                 val latch = CountDownLatch(1)
                 uiAutomation.setOnAccessibilityEventListener { latch.countDown() }
@@ -39,20 +32,7 @@ class ViewTreeDump : Instrumentation() {
                 }
                 latch.await(2, TimeUnit.SECONDS)
 
-                if (waitUntilIdle > 0) {
-                    UiDevice.getInstance(this).waitForIdle(waitUntilIdle)
-                }
-
-                val windows: List<AccessibilityWindowInfo> = uiAutomation.windows
-                roots = if (windows.isNotEmpty()) {
-                    windows.mapNotNull { it.root }
-                } else {
-                    listOfNotNull(uiAutomation.rootInActiveWindow)
-                }
-                windows.forEach { it.recycle() }
-
-                Log.i(TAG, "windows=${windows.size} roots=${roots.size}")
-                val json = serializeToJson(roots)
+                val json = UiTreeSerializer.dump(uiAutomation, this, waitUntilIdle)
                 Log.i(TAG, "JSON size: ${json.length} chars")
 
                 val result = Bundle()
@@ -67,55 +47,7 @@ class ViewTreeDump : Instrumentation() {
                 finish(Activity.RESULT_CANCELED, error)
             } finally {
                 uiAutomation.setOnAccessibilityEventListener(null)
-                roots.forEach { it.recycle() }
             }
         }.start()
-    }
-
-    private fun serializeToJson(roots: List<AccessibilityNodeInfo>): String {
-        val array = JSONArray()
-        for (root in roots) {
-            array.put(nodeToJson(root, 0))
-        }
-        return JSONObject().put("hierarchy", array).toString()
-    }
-
-    private fun nodeToJson(node: AccessibilityNodeInfo, index: Int): JSONObject {
-        val bounds = Rect()
-        node.getBoundsInScreen(bounds)
-
-        val obj = JSONObject()
-            .put("index", index)
-            .put("class", node.className?.toString() ?: "")
-            .put("package", node.packageName?.toString() ?: "")
-            .put("text", node.text?.toString() ?: "")
-            .put("content-desc", node.contentDescription?.toString() ?: "")
-            .put("resource-id", node.viewIdResourceName ?: "")
-            .put("checkable", node.isCheckable)
-            .put("checked", node.isChecked)
-            .put("clickable", node.isClickable)
-            .put("enabled", node.isEnabled)
-            .put("focusable", node.isFocusable)
-            .put("focused", node.isFocused)
-            .put("scrollable", node.isScrollable)
-            .put("long-clickable", node.isLongClickable)
-            .put("password", node.isPassword)
-            .put("selected", node.isSelected)
-            .put("visible", node.isVisibleToUser)
-            .put("rect", JSONObject()
-                .put("x", bounds.left).put("y", bounds.top)
-                .put("width", bounds.right - bounds.left).put("height", bounds.bottom - bounds.top))
-
-        val children = JSONArray()
-        for (i in 0 until node.childCount) {
-            val child = node.getChild(i) ?: continue
-            children.put(nodeToJson(child, i))
-            child.recycle()
-        }
-        if (children.length() > 0) {
-            obj.put("children", children)
-        }
-
-        return obj
     }
 }


### PR DESCRIPTION
… exec

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lightweight HTTP+JSON-RPC instrumentation server to dump the UI tree without spawning new processes, cutting latency for DeviceKit actions. Refactors the one-shot dumper to use a shared `UiTreeSerializer`, documents the new server flow, and hardens JSON-RPC error handling and socket cleanup.

- **New Features**
  - Added `DeviceKitServer` (registered in `AndroidManifest.xml`) that listens on `localabstract:devicekit` and serves JSON-RPC 2.0 over HTTP.
  - Supports `device.dump.ui` with optional `waitUntilIdle`; README shows `adb forward` and `curl` examples.
  - Introduced `UiTreeSerializer` that dumps all interactive windows or falls back to the active root, and separates `text` from `hint`.

- **Bug Fixes and Refactors**
  - `UiTreeSerializer`: recycle children with try/finally; fall back to `rootInActiveWindow` when window roots are null to avoid empty dumps.
  - `DeviceKitServer`: read exactly the posted bytes for the request body; close the `LocalServerSocket` in a `finally` block to release the abstract socket on errors.
  - JSON-RPC: replace magic numbers with constants; distinguish parse (-32700) vs internal (-32603) errors and preserve the request id in error responses.

<sup>Written for commit 39c4db8ce1a8464f5e563858fa992f824126b5af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

