### PR TITLE
feat: adding Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build clean install
+
+build:
+	./gradlew assembleDebug
+
+install:
+	adb install -r app/build/outputs/apk/debug/app-debug.apk
+
+clean:
+	./gradlew clean


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a Makefile with `build`, `install`, and `clean` targets to streamline Android debug builds: runs `./gradlew assembleDebug`, installs the debug APK via `adb install -r`, and cleans with `./gradlew clean`.

<sup>Written for commit 707a7abff976d444ede14acb51c793808d98900a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

