### PR TITLE
fix: derive version from git tag at release time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,11 @@ jobs:
       run: |
         mkdir dist
         chmod +x gradlew
-        ./gradlew assembleDebug
+        VERSION_ARG=""
+        if [ "${{ github.ref_type }}" = "tag" ]; then
+          VERSION_ARG="-PversionName=${{ github.ref_name }}"
+        fi
+        ./gradlew assembleDebug $VERSION_ARG
         mv app/build/outputs/apk/debug/app-debug.apk dist/mobilenext-devicekit.apk
 
     - name: Upload APK artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.2](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.2) (2026-06-14)
+* Fix: Derive APK versionName/versionCode from the git tag at release time, so the published version matches the release tag
+
 ## [1.2.1](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.1) (2026-06-14)
 * Feat: DeviceKit HTTP server for faster actions without spawning a process per call ([#22](https://github.com/mobile-next/devicekit-android/pull/22))
 * Feat: Package lister with app name and versions ([#13](https://github.com/mobile-next/devicekit-android/pull/13))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,16 @@ plugins {
     alias(libs.plugins.detekt)
 }
 
+// version name is supplied by the git tag at release time (-PversionName=x.y.z);
+// non-release builds fall back to a dev placeholder. versionCode is derived from it.
+val appVersionName = providers.gradleProperty("versionName").orNull ?: "0.0.0-dev"
+val appVersionCode = appVersionName
+    .substringBefore("-")
+    .split(".")
+    .mapNotNull { it.toIntOrNull() }
+    .let { if (it.size == 3) it[0] * 10000 + it[1] * 100 + it[2] else 1 }
+    .coerceAtLeast(1)
+
 android {
     namespace = "com.mobilenext.devicekit"
     compileSdk = 35
@@ -12,8 +22,8 @@ android {
         applicationId = "com.mobilenext.devicekit"
         minSdk = 29
         targetSdk = 35
-        versionCode = 3
-        versionName = "1.2.0"
+        versionCode = appVersionCode
+        versionName = appVersionName
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Problem

The APK published under release tag `1.2.1` shipped `versionName='1.2.0'` because `versionName` was hardcoded in `build.gradle.kts` and never bumped when tagging. Consumers that compare a device's reported `versionName` against the release tag (e.g. mobilecli's `agent install`) never match, causing repeated reinstalls.

## Fix

- Derive `versionName` from a Gradle property (`-PversionName=x.y.z`) and compute `versionCode` from it; non-release builds fall back to `0.0.0-dev`.
- CI passes the git tag name into the build on tag pushes, so a release tagged `1.2.2` ships `versionName='1.2.2'`.

## Verification

Built locally with `-PversionName=1.2.1`:
```
package: name='com.mobilenext.devicekit' versionCode='10201' versionName='1.2.1' ...
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derive APK `versionName` and `versionCode` from the git tag during release builds, so the published APK matches the release tag. Prevents reinstall loops in tools that compare the device `versionName` to the release tag.

- **Bug Fixes**
  - Gradle reads `-PversionName`; defaults to `0.0.0-dev` for non-release builds.
  - `versionCode` computed from `versionName` (e.g., 1.2.1 -> 10201), with a minimum of 1.
  - CI passes the tag name to Gradle on tag builds.

<sup>Written for commit 3ffc7390f1d8eaa18d5313afaa4e7d402139b695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

