### PR TITLE
ci+docs: publish devicekit.dex instead of APK; rewrite README for app_process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build Android APK
+name: Build devicekit.dex
 permissions:
   contents: read
 
@@ -62,13 +62,16 @@ jobs:
           VERSION_ARG="-PversionName=${{ github.ref_name }}"
         fi
         ./gradlew assembleDebug $VERSION_ARG
-        mv app/build/outputs/apk/debug/app-debug.apk dist/mobilenext-devicekit.apk
+        # The tools run via `app_process` from a single classes.dex, so publish
+        # that dex rather than the full APK. -j drops the archive path.
+        unzip -o -j app/build/outputs/apk/debug/app-debug.apk classes.dex -d dist
+        mv dist/classes.dex dist/devicekit.dex
 
-    - name: Upload APK artifact
+    - name: Upload dex artifact
       uses: actions/upload-artifact@v4
       with:
-        name: mobilenext-devicekit
-        path: dist/mobilenext-devicekit.apk
+        name: devicekit-dex
+        path: dist/devicekit.dex
         retention-days: 1
 
     - name: Upload to GitHub Release
@@ -77,5 +80,5 @@ jobs:
       with:
         name: Version ${{ github.ref_name }}
         files: |
-          dist/mobilenext-devicekit.apk
+          dist/devicekit.dex
   

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Mobile Next Device Kit
 
-An Android app that is a set of tools for controlling Android devices, changing configuration
-that is not possible through adb-shell alone.
+A set of tools for controlling Android devices and reading device state that is
+not possible through `adb shell` alone. The tools run **headless** via
+`app_process` straight from a single `classes.dex` — nothing needs to be
+installed on the device.
 
 <p align="center">
   <a href="https://github.com/mobile-next/devicekit-android">
@@ -20,127 +22,162 @@ that is not possible through adb-shell alone.
 
 ## Features
 
-- Control clipboard content with support for utf8
-- Stream screen buffer as mjpeg (with scaling and quality parameters)
-- Dump UI view tree as XML (instrumentation-based, no accessibility service required)
+- **Clipboard** — get, set (incl. base64), and clear the system clipboard
+- **UI tree dump** — dump the on-screen accessibility hierarchy as JSON
+- **Package list** — list installed packages with app name and version
+- **Screen streaming** — H.264 (AVC) or MJPEG, with scale/fps/quality options
+
+All of the above run from the published `devicekit.dex` with no app install.
 
 ## Installing
 
-Simply download the latest release from [github releases](https://github.com/mobile-next/devicekit-android/releases), install the package onto your device, and see **Usage** section below for commands.
+Download the latest `devicekit.dex` from
+[GitHub releases](https://github.com/mobile-next/devicekit-android/releases) and
+push it to the device:
 
-You may also just automate it all by running the copy-pasting the following script onto your terminal:
 ```bash
-curl -s -O -J -L https://github.com/mobile-next/devicekit-android/releases/download/1.1.13/mobilenext-devicekit.apk
-
-adb install -r mobilenext-devicekit.apk
+curl -s -O -J -L https://github.com/mobile-next/devicekit-android/releases/latest/download/devicekit.dex
+adb push devicekit.dex /data/local/tmp/
 ```
 
 ## Usage
 
-### Setting Clipboard via ADB
-
-Once the app is installed on your device or emulator, you can set the clipboard content using the following ADB command:
+Every tool is launched the same way — `app_process` with the dex on the
+classpath:
 
 ```bash
-adb shell 'am broadcast -a devicekit.clipboard.set -n com.mobilenext.devicekit/.ClipboardBroadcastReceiver -e text "this can be pasted now"'
+adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.<Tool> [args]
 ```
 
-### Clearing Clipboard via ADB
+The tools run as the `shell` user (uid 2000); no root is required.
+
+> For tools that emit **binary** output (the screen streamers) use
+> `adb exec-out` instead of `adb shell`, otherwise the stream is corrupted by
+> newline translation.
+
+### Clipboard
 
 ```bash
-adb shell am broadcast -a devicekit.clipboard.clear -n com.mobilenext.devicekit/.ClipboardBroadcastReceiver
+# Set the clipboard
+adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.Clipboard set "Hello World"
+
+# Set from base64 (safest for spaces, emoji, and other UTF-8) — "✌️"
+adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.Clipboard set --base64 "4pyM77iP"
+
+# Print the current clipboard text
+adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.Clipboard get
+
+# Clear the clipboard
+adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.Clipboard clear
 ```
 
-### Examples
+Since devicekit cannot force a keypress, paste with:
 
 ```bash
-# Set clipboard content
-adb shell 'am broadcast -a devicekit.clipboard.set -n com.mobilenext.devicekit/.ClipboardBroadcastReceiver -e text "Hello World"'
-
-# Using base64 for complex text (set 'encoding' to 'base64')
-adb shell am broadcast -a devicekit.clipboard.set -n com.mobilenext.devicekit/.ClipboardBroadcastReceiver -e encoding "base64" -e text "4pyM77iP"
-
-# Set special characters
-adb shell 'am broadcast -a devicekit.clipboard.set -n com.mobilenext.devicekit/.ClipboardBroadcastReceiver -e text "こんにちは世界"'
+adb shell input keyevent KEYCODE_PASTE
 ```
 
-Since **devicekit** cannot force a keypress, use `adb shell input keyevent KEYCODE_PASTE` to paste clipboard onto current input text field.
+### Dump the UI view tree
 
-Note that the single quotes after `adb shell` are required if your text includes spaces. The base64 encoding allows you to safely transfer whatever utf8 you wish to paste.
-
-### Dumping the UI View Tree
+Prints the current accessibility hierarchy as JSON to stdout:
 
 ```bash
-adb shell am instrument -w com.mobilenext.devicekit/.ViewTreeDump
+adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.UiDump
 ```
 
-The JSON hierarchy is returned inline in the `INSTRUMENTATION_STATUS: json=` line of the output.
+Optionally wait up to N milliseconds for the UI to go idle first (useful right
+after a navigation or transition):
 
-**Parameters:**
-
-| Parameter | Type | Description |
-|---|---|---|
-| `waitUntilIdle` | int (ms) | Wait up to N ms for the UI to become idle before dumping. Useful after a navigation or transition. Default: 0 (no wait). |
-
-Example with idle wait:
 ```bash
-adb shell am instrument -w -e waitUntilIdle 2000 com.mobilenext.devicekit/.ViewTreeDump
+adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.UiDump 2000
 ```
 
-### Using the HTTP Server
+### List installed packages
 
-For repeated queries, the one-shot `am instrument` invocation above pays the instrumentation startup cost on every call. The HTTP server starts once and stays resident, answering requests over a persistent connection.
-
-Start the server:
+Prints a JSON array of `{packageName, appName, version}`:
 
 ```bash
+adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.PackageLister
+```
+
+### Stream the screen as H.264 (AVC)
+
+Writes a raw H.264 (Annex-B) elementary stream to stdout:
+
+```bash
+adb exec-out CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.AvcServer --scale 0.5 --fps 30 > screen.h264
+```
+
+Pipe it straight into a player:
+
+```bash
+adb exec-out CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.AvcServer | ffplay -probesize 32 -sync ext -
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--bitrate` | int (bps) | 10000000 | Target bitrate (min 100000) |
+| `--scale` | float | 1.0 | Output scale, 0.1–2.0 |
+| `--fps` | int | 30 | Frame rate, 1–60 |
+
+### Stream the screen as MJPEG
+
+Writes a `multipart/x-mixed-replace` MJPEG stream to stdout:
+
+```bash
+adb exec-out CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.MjpegServer --quality 80 --scale 0.5 --fps 30 > screen.mjpeg
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `--quality` | int | 80 | JPEG quality, 1–100 |
+| `--scale` | float | 1.0 | Output scale, 0.1–2.0 |
+| `--fps` | int | 30 | Frame rate, 1–60 |
+
+## Resident JSON-RPC server (advanced)
+
+For repeated UI queries, `DeviceKitServer` starts once and stays resident,
+answering JSON-RPC over a persistent socket instead of paying process startup on
+every call. It is instrumentation-based, so it requires the **APK** to be
+installed (build it from source — see below):
+
+```bash
+# Start the server (leave running or background it)
 adb shell am instrument -w com.mobilenext.devicekit/.DeviceKitServer
 ```
 
-It listens on the abstract socket `localabstract:devicekit` and keeps running until the instrumentation is stopped. Leave this command running (or background it).
-
-Forward a local TCP port to the socket:
+It listens on `localabstract:devicekit`. Forward a local port and query it:
 
 ```bash
 adb forward tcp:8080 localabstract:devicekit
-```
 
-Fetch the UI tree with a JSON-RPC request over `curl`:
-
-```bash
-curl -s http://localhost:8080 \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"device.dump.ui","params":{}}'
-```
-
-The response is a JSON-RPC envelope whose `result` holds the `hierarchy` tree. The optional `waitUntilIdle` parameter (milliseconds) behaves as above:
-
-```bash
 curl -s http://localhost:8080 \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"device.dump.ui","params":{"waitUntilIdle":2000}}'
-```
 
-Remove the forward when done:
-
-```bash
 adb forward --remove tcp:8080
 ```
 
-## Installation
-
-1. Build the APKs using Android Studio or Gradle
-2. Install: `adb install app/build/outputs/apk/debug/app-debug.apk`
-3. Use the ADB commands above
-
-## Debugging
-
-The app logs all broadcast reception events. You can view logs using:
+## Building from source
 
 ```bash
-adb logcat -s ClipboardReceiver
+./gradlew assembleDebug
+```
+
+The dex used by all the `app_process` tools is inside the built APK:
+
+```bash
+unzip -o -j app/build/outputs/apk/debug/app-debug.apk classes.dex -d .
+adb push classes.dex /data/local/tmp/devicekit.dex
+```
+
+To use the instrumentation-based resident server, install the APK instead:
+
+```bash
+adb install app/build/outputs/apk/debug/app-debug.apk
 ```
 
 ## Requirements
 
-- Android 10 (API 29) minimum
+- Android 10 (API 29) or newer
+- Tools run in the `adb shell` (uid 2000) context; no root required


### PR DESCRIPTION
## Summary

The toolkit has become a set of standalone **`app_process`** tools that run from a single `classes.dex` with no app install. This PR makes the published artifact match that reality and rewrites the README around it.

## CI (`.github/workflows/build.yaml`)

- Build still runs `./gradlew assembleDebug`, then **extracts `classes.dex`** from the APK and publishes it as `devicekit.dex` (artifact + GitHub release asset) instead of the APK.
- Renamed the workflow and artifact accordingly.

## README

Rewritten around the app_process model. Every feature now has a copy-paste `adb` command:

- **Clipboard** — `get` / `set` / `set --base64` / `clear`
- **UiDump** — UI hierarchy as JSON (+ optional idle wait)
- **PackageLister** — installed packages as JSON
- **AvcServer** — H.264 stream (with `--bitrate/--scale/--fps`)
- **MjpegServer** — MJPEG stream (with `--quality/--scale/--fps`)
- Documents `adb exec-out` for the binary streamers (vs `adb shell` for text tools)
- Keeps the resident **DeviceKitServer** documented as the APK-based "advanced" option (it's instrumentation-based, so it still needs the installed APK)
- Adds a "Building from source" section covering both dex extraction and APK install

## ⚠️ Merge ordering

The README documents `UiDump` and `Clipboard`, whose entry points land in **#28** and **#29**. This PR should merge **after** those (or alongside) so the docs match the published dex. `PackageLister`/`AvcServer`/`MjpegServer` are already in `main`.

## Verification

- `build.yaml` passes YAML lint; dex-extraction commands verified locally (produce a valid `Dalvik dex file`).
- All documented commands were exercised on an emulator (API 37) in the feature PRs.

## Note

With the APK no longer released, the instrumentation-based `DeviceKitServer` requires building the APK from source. A natural follow-up is to migrate it to an `app_process` entry point (it can reuse `UiAutomationFactory` + `LocalServerSocket`), which would make the dex the only artifact anyone needs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the release artifact from the APK to `devicekit.dex` and rewrites the README around one-shot `app_process` tools with copy‑paste `adb` commands. This matches how the toolkit runs and removes the need to install an app.

- **Refactors**
  - CI now extracts `classes.dex` from the assembled APK and publishes it as `devicekit.dex` (artifact + release asset).
  - Workflow and artifact names updated to reflect the dex artifact.

- **Migration**
  - Download `devicekit.dex`, push it to `/data/local/tmp/`, and run tools via:
    `adb shell CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenext.devicekit.<Tool> [args]`.
  - Use `adb exec-out` for binary streamers (`AvcServer`, `MjpegServer`); text tools can use `adb shell`.
  - `DeviceKitServer` (resident JSON‑RPC) still requires the APK built from source.

<sup>Written for commit bbc541c1614d22051bd1b6d786728b23a526e55f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

