### PR TITLE
fix: keep UI dump best-effort when waitForIdle times out

### DIFF
--- a/app/src/main/java/com/mobilenext/devicekit/UiTreeSerializer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/UiTreeSerializer.kt
@@ -2,12 +2,16 @@ package com.mobilenext.devicekit
 
 import android.app.UiAutomation
 import android.graphics.Rect
+import android.util.Log
 import android.view.accessibility.AccessibilityNodeInfo
 import android.view.accessibility.AccessibilityWindowInfo
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.concurrent.TimeoutException
 
 object UiTreeSerializer {
+
+    private const val TAG = "UiTreeSerializer"
 
     // The UI must be quiet for this long before waitForIdle returns, bounded by
     // the caller-supplied global timeout. Mirrors UiDevice.waitForIdle semantics.
@@ -15,7 +19,14 @@ object UiTreeSerializer {
 
     fun dump(uiAutomation: UiAutomation, waitUntilIdle: Long = 0L): String {
         if (waitUntilIdle > 0) {
-            uiAutomation.waitForIdle(IDLE_WINDOW_MS, waitUntilIdle)
+            // Best-effort settle: UiAutomation.waitForIdle throws TimeoutException
+            // when the UI never goes idle (animations, video, spinners). Swallow it
+            // and dump the current state, matching the old UiDevice.waitForIdle.
+            try {
+                uiAutomation.waitForIdle(IDLE_WINDOW_MS, waitUntilIdle)
+            } catch (e: TimeoutException) {
+                Log.w(TAG, "UI not idle within ${waitUntilIdle}ms; dumping current state", e)
+            }
         }
 
         val windows: List<AccessibilityWindowInfo> = uiAutomation.windows


### PR DESCRIPTION
## Problem

`UiTreeSerializer.dump` calls `UiAutomation.waitForIdle(idleTimeout, globalTimeout)`, which declares **`throws TimeoutException`** (a checked exception) and throws when the UI never reaches idle within the timeout. Kotlin doesn't enforce checked exceptions, so it compiled without a `try/catch` — but at runtime the `TimeoutException` propagates out of `dump()` to **all** callers (`UiDump`, `DeviceKitServer`, `ViewTreeDump`).

The `UiDevice.waitForIdle()` this replaced (in the headless refactor) **swallows** that timeout internally and proceeds. So the refactor silently changed behavior:

- **Before:** wait for idle, but if it never settles, dump the current state (best-effort).
- **After:** any screen that doesn't go idle within `waitUntilIdle` — animations, video, spinners, live content — makes the **entire dump fail** with a `TimeoutException`.

The code comment even claimed it "Mirrors UiDevice.waitForIdle semantics", which it didn't.

## Fix

Catch `TimeoutException` around `waitForIdle`, log a warning, and proceed with the dump — restoring best-effort semantics.

## Verification (emulator, API 37)

- Normal path (`UiDump 2000` on an idle screen) → hierarchy returned, no warning.
- **Forced-timeout path** (`UiDump 100` — needs 500 ms of idle within a 100 ms global timeout, so `waitForIdle` is guaranteed to throw) → dump **still succeeds** (returns the hierarchy) and logs `UiTreeSerializer: UI not idle within 100ms; dumping current state`. Pre-fix, this same input would have failed the dump.
- `./gradlew assembleDebug` + `detekt` pass.

## Credit

Flagged by an automated review comment on the headless-UiAutomation change (PR #28), which introduced this regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore best-effort UI dumps by catching `TimeoutException` from `UiAutomation.waitForIdle(...)`, so dumps still succeed on non-idle screens (animations, video, spinners). This matches previous `UiDevice.waitForIdle` behavior.

- **Bug Fixes**
  - Wrap `waitForIdle` in try/catch in `UiTreeSerializer.dump`; on timeout, log a warning and proceed with the dump.

<sup>Written for commit 9f75d967434c581117fb383764f5e7eb60b385fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

