### PR TITLE
fix: re-remove unused UI deps that inflated classes.dex

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,13 +56,6 @@ android {
 
 dependencies {
 
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.tracing)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    implementation(libs.androidx.uiautomator) {
-        exclude(group = "junit", module = "junit")
-    }
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }


### PR DESCRIPTION
## Problem

`classes.dex` is back to ~950KB. The `dependencies` block on `main` once again lists all five UI libraries:

```kotlin
implementation(libs.androidx.core.ktx)
implementation(libs.androidx.tracing)
implementation(libs.androidx.appcompat)
implementation(libs.material)
implementation(libs.androidx.uiautomator) { exclude(...) }
```

## Root cause

The cleanup landed in #26 (removed material/appcompat/core-ktx/tracing) and #28 (removed uiautomator). But the feature branches (#27/#28/#29) were all cut from `main` **before #26 merged**, so their copies of `build.gradle.kts` still had the full list. Merging them restored the deps and undid the shrink. (The other half of #26 — the framework theme and deleted `values-night` — survived, since those files weren't touched by the feature PRs.)

## Fix

Strip the unused deps again. Verified none are actually referenced:
- theme is `@android:style/Theme.Material.Light.NoActionBar` (framework, no library)
- `UiDevice` was replaced by `UiAutomationFactory`; no source imports any of the five libs

## Verification

- `./gradlew assembleDebug` passes.
- `classes.dex`: **~950KB → 49,876 bytes**; 0 `material`/`appcompat`/`uiautomator` classes in the dex.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-removed unused UI dependencies from `app/build.gradle.kts` to undo a regression that inflated `classes.dex`. Size drops from ~950KB to ~49KB.

- **Dependencies**
  - Removed: `libs.androidx.core.ktx`, `libs.androidx.tracing`, `libs.androidx.appcompat`, `libs.material`, `libs.androidx.uiautomator`.
  - No usages in code (framework theme; `UiAutomationFactory` replaces `UiDevice`); `./gradlew assembleDebug` passes.

<sup>Written for commit 229c6952171ed317bc22b587b9747e923e7dda3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

