### PR TITLE
fix: cap AVC encoder at 3 Mbps CBR to stop bursty flooding

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ adb exec-out CLASSPATH=/data/local/tmp/devicekit.dex app_process / com.mobilenex
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `--bitrate` | int (bps) | 10000000 | Target bitrate (min 100000) |
+| `--bitrate` | int (bps) | 3000000 | Target bitrate, CBR (min 100000) |
 | `--scale` | float | 1.0 | Output scale, 0.1–2.0 |
 | `--fps` | int | 30 | Frame rate, 1–60 |
 

--- a/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
@@ -18,7 +18,7 @@ import kotlin.system.exitProcess
 class AvcServer(private val bitrate: Int, private val scale: Float, private val fps: Int) {
     companion object {
         private const val TAG = "AvcServer"
-        private const val DEFAULT_BITRATE = 10_000_000  // 10 Mbps (Google's default)
+        private const val DEFAULT_BITRATE = 3_000_000  // 3 Mbps — sane ceiling for screen mirroring over constrained links
         private const val DEFAULT_SCALE = 1.0f
         private const val DEFAULT_FPS = 30
         private const val MIN_FPS = 1
@@ -179,6 +179,10 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
             scaledHeight
         ).apply {
             setInteger(MediaFormat.KEY_BIT_RATE, bitrate)
+            // CBR caps the encoder's peak rate so a burst of motion can't flood a
+            // constrained viewer link (VBR was spiking to ~9 Mbps). A static screen
+            // still idles low because surface input only feeds duplicate frames.
+            setInteger(MediaFormat.KEY_BITRATE_MODE, MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR)
             setInteger(MediaFormat.KEY_FRAME_RATE, fps)
             setInteger(MediaFormat.KEY_CAPTURE_RATE, fps)  // Set capture rate to match frame rate
             setFloat(MediaFormat.KEY_OPERATING_RATE, fps.toFloat())  // Set operating rate


### PR DESCRIPTION
## Problem

The browser device-view freezes and drops frames. Diagnosis from `webrtc-server` GCC logs + Chrome WebRTC stats:

- The viewer's estimated downlink (server-side GCC) is ~0.3–1 Mbps, but the device encodes **4–9.4 Mbps** in bursts.
- There is **no packet loss** (`fraction_lost=0`) — the path absorbs the flood into buffers, so RTT climbs to ~545ms and the jitter buffer balloons to ~1.7s. That late-frame buildup is what freezes/drops the picture.

Root cause on the device side: `AvcServer` runs the H.264 encoder in **VBR** with a **10 Mbps** default, so motion spikes far above any sane ceiling.

## Change

- `DEFAULT_BITRATE` 10 Mbps → **3 Mbps**
- Set `KEY_BITRATE_MODE = BITRATE_MODE_CBR` so peaks are capped at the target instead of overshooting. A static screen still idles low because surface input only feeds duplicate (skip) frames.
- README default updated.

## Verify

Rebuild/redeploy the APK, then watch `RTP stats: … writeBytesDelta` in the webrtc-server logs:
- Motion should cap near 3 Mbps instead of ~9 Mbps.
- A frozen screen should fall toward zero. (If a specific encoder bit-stuffs to hold CBR, it would stay ~3 Mbps — then switch to `BITRATE_MODE_CBR_FD` or VBR-with-max.)

## Scope

Stage 1 of closing the bitrate control loop: a fixed ceiling that stops the flooding. Stage 2 (separate, spans webrtc-server / mobilecli / mobilefleet-client / devicekit) makes the device **adapt** to the viewer's measured downlink via REMB + runtime bitrate updates.

