### PR TITLE
ci: publish devicekit.apk alongside the dex in releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,7 @@ jobs:
         # that dex rather than the full APK. -j drops the archive path.
         unzip -o -j app/build/outputs/apk/debug/app-debug.apk classes.dex -d dist
         mv dist/classes.dex dist/devicekit.dex
+        cp app/build/outputs/apk/debug/app-debug.apk dist/devicekit.apk
 
     - name: Upload dex artifact
       uses: actions/upload-artifact@v4
@@ -81,4 +82,5 @@ jobs:
         name: Version ${{ github.ref_name }}
         files: |
           dist/devicekit.dex
+          dist/devicekit.apk
   


### PR DESCRIPTION
Releases currently only publish `devicekit.dex`. This also copies the built APK to `dist/devicekit.apk` and attaches it to the GitHub Release, so both artifacts ship.

## Test plan
- [ ] Push a `*.*.*` tag and confirm the release contains both `devicekit.dex` and `devicekit.apk`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `devicekit.apk` alongside `devicekit.dex` in GitHub Releases so both the full APK and the dex are available. The workflow now copies `app/build/outputs/apk/debug/app-debug.apk` to `dist/devicekit.apk` and uploads it with the release.

<sup>Written for commit cc432d7a1ddc837633967c6bd0b0aa839b16ff0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

