### PR TITLE
docs: updated readme and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,20 @@
 * Feat: Added UI view tree dump service via instrumentation, as a workaround for UIAutomator2 timeouts during animations ([#14](https://github.com/mobile-next/devicekit-android/pull/14))
 * Fix: Reduced APK size by ~50% by removing over-broad ProGuard keep rules ([#14](https://github.com/mobile-next/devicekit-android/pull/14))
 
-## [1.1.5](https://github.com/mobile-next/mobile-mcp/releases/tag/1.1.5) (2025-12-07)
+## [1.1.5](https://github.com/mobile-next/devicekit-android/releases/tag/1.1.5) (2025-12-07)
 * Fixed: AVC encoder latency issues with reduced timeout
 * Fixed: Repeating frames bug, where screen had to change in order for stream to send bytes
 * Fixed: Proper shutdown and resource cleanup when stdout pipe is broken
 * Fixed: AVC stream shutdown when stdout closes
 
-## [1.1.4](https://github.com/mobile-next/mobile-mcp/releases/tag/1.1.4) (2025-11-29)
+## [1.1.4](https://github.com/mobile-next/devicekit-android/releases/tag/1.1.4) (2025-11-29)
 * Feat: Added support for AVC (H.264) codec for screencapture
 * Feat: Added --fps flag to control frame rate
 * Fix: Stop screen capture and streaming when stdout is closed
 
-## [1.1.3](https://github.com/mobile-next/mobile-mcp/releases/tag/1.1.3) (2025-09-04)
+## [1.1.3](https://github.com/mobile-next/devicekit-android/releases/tag/1.1.3) (2025-09-04)
 * Feat: New --scale and --quality parameters when encoding mjpeg stream ([#5](https://github.com/mobile-next/devicekit-android/pull/5))
 
-## [1.1.2](https://github.com/mobile-next/mobile-mcp/releases/tag/1.1.2) (2025-07-31)
+## [1.1.2](https://github.com/mobile-next/devicekit-android/releases/tag/1.1.2) (2025-07-31)
 * Fix: Enabled proguard optimization to reduce .apk file size
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ installed on the device.
   <a href="https://github.com/mobile-next/devicekit-android/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/license-FSL--1.1--Apache--2.0-blue.svg" alt="License" />
   </a>
-  <a href="http://mobilenexthq.com/join-slack">
+  <a href="https://mobilenext.ai/join-slack">
     <img src="https://img.shields.io/badge/join-Slack-blueviolet?logo=slack&style=flat" alt="Slack community channel" />
   </a>
 </p>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrects broken docs links to prevent 404s and point users to the right pages. CHANGELOG release URLs now target `mobile-next/devicekit-android`, and the README Slack link is `https://mobilenext.ai/join-slack`.

<sup>Written for commit d86f2d08649ef047bf5465e3739242d2d46c2c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

