### PR TITLE
feat: live encoder control over localabstract JSON-RPC socket

### DIFF
--- a/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
@@ -4,10 +4,12 @@ import android.hardware.display.VirtualDisplay
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
 import android.media.MediaFormat
+import android.os.Bundle
 import android.os.IBinder
 import android.util.Log
 import android.view.Display
 import android.view.Surface
+import org.json.JSONObject
 import java.io.FileDescriptor
 import java.io.FileOutputStream
 import java.io.IOException
@@ -19,11 +21,17 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
     companion object {
         private const val TAG = "AvcServer"
         private const val DEFAULT_BITRATE = 3_000_000  // 3 Mbps — sane ceiling for screen mirroring over constrained links
+        private const val MIN_BITRATE = 100_000        // 100 kbps floor for adaptive control
+        private const val MAX_BITRATE = 10_000_000      // 10 Mbps ceiling for adaptive control
         private const val DEFAULT_SCALE = 1.0f
         private const val DEFAULT_FPS = 30
         private const val MIN_FPS = 1
         private const val MAX_FPS = 60
-        private const val I_FRAME_INTERVAL = 1  // 1 second
+        private const val I_FRAME_INTERVAL = 2  // 2s — 3s created larger bursts than 1s; tuning down
+
+        // localabstract socket name for the live encoder control channel; the host
+        // forwards to it (adb forward tcp:N localabstract:devicekit-avc).
+        private const val CONTROL_SOCKET = "devicekit-avc"
 
         @JvmStatic
         fun main(args: Array<String>) {
@@ -48,7 +56,9 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
                 when (args[i]) {
                     "--bitrate" -> {
                         if (i + 1 < args.size) {
-                            bitrate = args[i + 1].toIntOrNull()?.coerceAtLeast(100_000) ?: DEFAULT_BITRATE
+                            // Clamp startup bitrate to the same bounds as live updates
+                            // so --bitrate can't bypass the MAX_BITRATE ceiling.
+                            bitrate = args[i + 1].toIntOrNull()?.coerceIn(MIN_BITRATE, MAX_BITRATE) ?: DEFAULT_BITRATE
                             i++
                         }
                     }
@@ -126,6 +136,50 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
             virtualDisplay?.release()
         } catch (e: Exception) {
             Log.e(TAG, "Error releasing virtual display", e)
+        }
+    }
+
+    // startControlServer exposes live encoder control over a localabstract JSON-RPC
+    // socket. The host reaches it with `adb forward tcp:N localabstract:<CONTROL_SOCKET>`
+    // and POSTs "screencapture.setBitrate" / "screencapture.requestKeyFrame". Stdin
+    // can't be used: AvcServer is launched via `adb exec-out`, whose stdin is not
+    // forwarded to the device process (exec-out is output-only) — a socket is the
+    // only channel that reaches this shell-uid process. Control is best-effort: if
+    // the socket can't bind, streaming continues unaffected.
+    private fun startControlServer(codec: MediaCodec) {
+        try {
+            JsonRpcSocketServer(CONTROL_SOCKET) { method, params ->
+                when (method) {
+                    "screencapture.setBitrate" -> {
+                        val bps = params?.optInt("bps", -1) ?: -1
+                        if (bps <= 0) {
+                            throw JsonRpcSocketServer.RpcException(
+                                JsonRpcSocketServer.ERROR_INTERNAL,
+                                "setBitrate requires a positive 'bps'",
+                            )
+                        }
+                        val clamped = bps.coerceIn(MIN_BITRATE, MAX_BITRATE)
+                        codec.setParameters(Bundle().apply {
+                            putInt(MediaCodec.PARAMETER_KEY_VIDEO_BITRATE, clamped)
+                        })
+                        Log.d(TAG, "Applied live bitrate: $clamped bps")
+                        JSONObject().put("bitrate", clamped)
+                    }
+                    "screencapture.requestKeyFrame" -> {
+                        codec.setParameters(Bundle().apply {
+                            putInt(MediaCodec.PARAMETER_KEY_REQUEST_SYNC_FRAME, 0)
+                        })
+                        Log.d(TAG, "Requested immediate sync frame")
+                        JSONObject().put("ok", true)
+                    }
+                    else -> throw JsonRpcSocketServer.RpcException(
+                        JsonRpcSocketServer.ERROR_METHOD_NOT_FOUND,
+                        "Method not found: $method",
+                    )
+                }
+            }.startDaemon()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to start control server; live control unavailable", e)
         }
     }
 
@@ -236,6 +290,11 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
         // Start codec
         codec.start()
         Log.d(TAG, "AVC encoder started")
+
+        // Expose live encoder control (bitrate, keyframe) over a localabstract
+        // socket so the host can adapt to the viewer's measured downlink without
+        // restarting the stream.
+        startControlServer(codec)
 
         val bufferInfo = MediaCodec.BufferInfo()
         val timeout = 100_000L  // 100ms timeout for responsive shutdown (matches REPEAT_FRAME_DELAY)

--- a/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/DeviceKitServer.kt
@@ -2,28 +2,15 @@ package com.mobilenext.devicekit
 
 import android.app.Activity
 import android.app.Instrumentation
-import android.app.UiAutomation
-import android.net.LocalServerSocket
-import android.net.LocalSocket
 import android.os.Bundle
 import android.util.Log
 import org.json.JSONObject
-import java.io.BufferedReader
-import java.io.InputStreamReader
 
 class DeviceKitServer : Instrumentation() {
 
     companion object {
         private const val TAG = "DeviceKitServer"
         private const val SOCKET_NAME = "devicekit"
-
-        // JSON-RPC 2.0 protocol (https://www.jsonrpc.org/specification)
-        private const val JSONRPC_VERSION = "2.0"
-
-        // JSON-RPC 2.0 standard error codes
-        private const val JSONRPC_PARSE_ERROR = -32700
-        private const val JSONRPC_METHOD_NOT_FOUND = -32601
-        private const val JSONRPC_INTERNAL_ERROR = -32603
     }
 
     override fun onCreate(arguments: Bundle?) {
@@ -33,104 +20,26 @@ class DeviceKitServer : Instrumentation() {
 
     private fun runServer() {
         val uiAutomation = uiAutomation
-        var serverSocket: LocalServerSocket? = null
         try {
             UiAutomationFactory.configureForWindowRetrieval(uiAutomation)
 
-            serverSocket = LocalServerSocket(SOCKET_NAME)
-            Log.i(TAG, "Listening on localabstract:$SOCKET_NAME")
-
-            while (true) {
-                val conn = serverSocket.accept()
-                try {
-                    handleConnection(conn, uiAutomation)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error handling connection", e)
-                } finally {
-                    conn.close()
+            JsonRpcSocketServer(SOCKET_NAME) { method, params ->
+                when (method) {
+                    "device.dump.ui" -> {
+                        val waitUntilIdle = params?.optLong("waitUntilIdle") ?: 0L
+                        JSONObject(UiTreeSerializer.dump(uiAutomation, waitUntilIdle))
+                    }
+                    else -> throw JsonRpcSocketServer.RpcException(
+                        JsonRpcSocketServer.ERROR_METHOD_NOT_FOUND,
+                        "Method not found: $method",
+                    )
                 }
-            }
+            }.start()
         } catch (e: Exception) {
             Log.e(TAG, "Server error", e)
             val error = Bundle()
             error.putString("error", e.message ?: e.javaClass.simpleName)
             finish(Activity.RESULT_CANCELED, error)
-        } finally {
-            serverSocket?.close()
         }
     }
-
-    private fun handleConnection(conn: LocalSocket, uiAutomation: UiAutomation) {
-        val reader = BufferedReader(InputStreamReader(conn.inputStream, Charsets.ISO_8859_1))
-
-        reader.readLine() ?: return
-
-        var contentLength = 0
-        var line = reader.readLine()
-        while (line != null && line.isNotEmpty()) {
-            if (line.lowercase().startsWith("content-length:")) {
-                contentLength = line.substring(15).trim().toIntOrNull() ?: 0
-            }
-            line = reader.readLine()
-        }
-
-        val bodyChars = CharArray(contentLength)
-        var offset = 0
-        while (offset < contentLength) {
-            val n = reader.read(bodyChars, offset, contentLength - offset)
-            if (n == -1) break
-            offset += n
-        }
-        val body = String(bodyChars, 0, offset)
-
-        val responseJson = handleJsonRpc(body, uiAutomation)
-        val responseBytes = responseJson.toByteArray(Charsets.UTF_8)
-
-        val httpResponse = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${responseBytes.size}\r\nConnection: close\r\n\r\n"
-        conn.outputStream.write(httpResponse.toByteArray(Charsets.UTF_8))
-        conn.outputStream.write(responseBytes)
-        conn.outputStream.flush()
-    }
-
-    private fun handleJsonRpc(body: String, uiAutomation: UiAutomation): String {
-        val request: JSONObject
-        try {
-            request = JSONObject(body)
-        } catch (e: Exception) {
-            Log.e(TAG, "JSON parse error", e)
-            return jsonRpcError(null, JSONRPC_PARSE_ERROR, "Parse error: ${e.message}")
-        }
-
-        val id = request.opt("id")
-        return try {
-            val method = request.optString("method")
-            val params = request.optJSONObject("params")
-
-            when (method) {
-                "device.dump.ui" -> {
-                    val waitUntilIdle = params?.optLong("waitUntilIdle") ?: 0L
-                    val hierarchy = JSONObject(UiTreeSerializer.dump(uiAutomation, waitUntilIdle))
-                    jsonRpcResult(id, hierarchy)
-                }
-                else -> jsonRpcError(id, JSONRPC_METHOD_NOT_FOUND, "Method not found: $method")
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Internal error", e)
-            jsonRpcError(id, JSONRPC_INTERNAL_ERROR, "Internal error: ${e.message}")
-        }
-    }
-
-    private fun jsonRpcResult(id: Any?, result: Any): String =
-        JSONObject()
-            .put("jsonrpc", JSONRPC_VERSION)
-            .put("id", id ?: JSONObject.NULL)
-            .put("result", result)
-            .toString()
-
-    private fun jsonRpcError(id: Any?, code: Int, message: String): String =
-        JSONObject()
-            .put("jsonrpc", JSONRPC_VERSION)
-            .put("id", id ?: JSONObject.NULL)
-            .put("error", JSONObject().put("code", code).put("message", message))
-            .toString()
 }

--- a/app/src/main/java/com/mobilenext/devicekit/JsonRpcSocketServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/JsonRpcSocketServer.kt
@@ -1,0 +1,160 @@
+package com.mobilenext.devicekit
+
+import android.net.LocalServerSocket
+import android.net.LocalSocket
+import android.util.Log
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
+
+// JsonRpcSocketServer serves JSON-RPC 2.0 over a localabstract socket, one
+// request per connection framed as HTTP/1.1 (Content-Length + body). The host
+// reaches it with `adb forward tcp:N localabstract:<name>` and a plain POST.
+//
+// It is shared by the two devicekit control surfaces that run as different
+// processes and uids: DeviceKitServer (Instrumentation, app uid, uiAutomation)
+// and AvcServer's encoder control socket (app_process, shell uid, MediaCodec).
+// Both need the same framing; only the dispatched methods differ.
+class JsonRpcSocketServer(
+    private val socketName: String,
+    private val dispatch: (method: String, params: JSONObject?) -> Any,
+) {
+    companion object {
+        private const val TAG = "JsonRpcSocketServer"
+        private const val JSONRPC_VERSION = "2.0"
+
+        // JSON-RPC 2.0 standard error codes
+        const val ERROR_PARSE = -32700
+        const val ERROR_METHOD_NOT_FOUND = -32601
+        const val ERROR_INTERNAL = -32603
+
+        private const val CONTENT_LENGTH_PREFIX = "content-length:"
+    }
+
+    // A dispatch handler throws RpcException to return a specific JSON-RPC error
+    // instead of the generic internal error.
+    class RpcException(val code: Int, override val message: String) : Exception(message)
+
+    @Volatile
+    private var running = true
+    private var serverSocket: LocalServerSocket? = null
+
+    // start binds the socket and serves connections on the calling thread until
+    // stop() is called or the socket errors. Blocking.
+    fun start() {
+        val socket = LocalServerSocket(socketName)
+        serverSocket = socket
+        Log.i(TAG, "Listening on localabstract:$socketName")
+        while (running) {
+            val conn = try {
+                socket.accept()
+            } catch (e: Exception) {
+                if (running) Log.e(TAG, "accept failed on $socketName", e)
+                break
+            }
+            try {
+                handleConnection(conn)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error handling connection", e)
+            } finally {
+                try {
+                    conn.close()
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    // startDaemon runs start() on a daemon thread and returns immediately.
+    fun startDaemon(): Thread {
+        val thread = Thread {
+            try {
+                start()
+            } catch (e: Exception) {
+                Log.e(TAG, "server on $socketName stopped: ${e.message}")
+            }
+        }
+        thread.isDaemon = true
+        thread.name = "jsonrpc-$socketName"
+        thread.start()
+        return thread
+    }
+
+    fun stop() {
+        running = false
+        try {
+            serverSocket?.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun handleConnection(conn: LocalSocket) {
+        val reader = BufferedReader(InputStreamReader(conn.inputStream, StandardCharsets.ISO_8859_1))
+
+        reader.readLine() ?: return // request line
+
+        var contentLength = 0
+        var line = reader.readLine()
+        while (line != null && line.isNotEmpty()) {
+            if (line.lowercase().startsWith(CONTENT_LENGTH_PREFIX)) {
+                contentLength = line.substring(CONTENT_LENGTH_PREFIX.length).trim().toIntOrNull() ?: 0
+            }
+            line = reader.readLine()
+        }
+
+        val bodyChars = CharArray(contentLength)
+        var offset = 0
+        while (offset < contentLength) {
+            val n = reader.read(bodyChars, offset, contentLength - offset)
+            if (n == -1) break
+            offset += n
+        }
+        val body = String(bodyChars, 0, offset)
+
+        val responseJson = handleJsonRpc(body)
+        val responseBytes = responseJson.toByteArray(StandardCharsets.UTF_8)
+
+        val httpResponse = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" +
+            "Content-Length: ${responseBytes.size}\r\nConnection: close\r\n\r\n"
+        conn.outputStream.write(httpResponse.toByteArray(StandardCharsets.UTF_8))
+        conn.outputStream.write(responseBytes)
+        conn.outputStream.flush()
+    }
+
+    private fun handleJsonRpc(body: String): String {
+        val request: JSONObject
+        try {
+            request = JSONObject(body)
+        } catch (e: Exception) {
+            Log.e(TAG, "JSON parse error", e)
+            return jsonRpcError(null, ERROR_PARSE, "Parse error: ${e.message}")
+        }
+
+        val id = request.opt("id")
+        return try {
+            val method = request.optString("method")
+            val params = request.optJSONObject("params")
+            jsonRpcResult(id, dispatch(method, params))
+        } catch (e: RpcException) {
+            jsonRpcError(id, e.code, e.message)
+        } catch (e: Exception) {
+            Log.e(TAG, "Internal error", e)
+            jsonRpcError(id, ERROR_INTERNAL, "Internal error: ${e.message}")
+        }
+    }
+
+    private fun jsonRpcResult(id: Any?, result: Any): String =
+        JSONObject()
+            .put("jsonrpc", JSONRPC_VERSION)
+            .put("id", id ?: JSONObject.NULL)
+            .put("result", result)
+            .toString()
+
+    private fun jsonRpcError(id: Any?, code: Int, message: String?): String =
+        JSONObject()
+            .put("jsonrpc", JSONRPC_VERSION)
+            .put("id", id ?: JSONObject.NULL)
+            .put("error", JSONObject().put("code", code).put("message", message ?: ""))
+            .toString()
+}


### PR DESCRIPTION
Replace the (dead) stdin control channel with a localabstract JSON-RPC socket in AvcServer, the shell-uid process that owns the MediaCodec. The host reaches it with `adb forward tcp:N localabstract:devicekit-avc` and POSTs screencapture.setBitrate / screencapture.requestKeyFrame; both call codec.setParameters live, no stream restart.

Stdin cannot work: AvcServer is launched via `adb exec-out`, whose stdin is not forwarded to the device process (exec-out is output-only), so the prior stdin-based approach was a silent no-op.

- Add JsonRpcSocketServer: shared JSON-RPC 2.0 over one-shot HTTP framing, extracted from DeviceKitServer so both control surfaces use one impl.
- Refactor DeviceKitServer onto the shared server (device.dump.ui intact).
- Clamp startup --bitrate to MIN_BITRATE..MAX_BITRATE (was floor only).

Verified on a Pixel 5: encoder output tracked live commands 8054->504->
7989 kbps, requestKeyFrame emitted an IDR on demand, device.dump.ui and the method-not-found path still work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a localabstract JSON‑RPC control socket to AvcServer and remove the dead stdin channel. The host connects via `adb forward tcp:N localabstract:devicekit-avc` to set bitrate or request keyframes without restarting the stream.

- **New Features**
  - AvcServer exposes `screencapture.setBitrate` and `screencapture.requestKeyFrame` over JSON‑RPC; changes apply via `MediaCodec.setParameters` with no stream restart.
  - Added shared `JsonRpcSocketServer` (HTTP one‑shot + JSON‑RPC 2.0) for control surfaces.
  - Clamp startup `--bitrate` to 100 kbps–10 Mbps.

- **Refactors**
  - `DeviceKitServer` now uses `JsonRpcSocketServer`; `device.dump.ui` unchanged.
  - Removed stdin control (was ineffective under `adb exec-out`).

<sup>Written for commit b5b99cc6e2e6798eda43b0c71105a7778e8eee66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

