### PR TITLE
fix: some code fixes around the new jsonrpc server for AVC control

### DIFF
--- a/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/AvcServer.kt
@@ -14,6 +14,7 @@ import java.io.FileDescriptor
 import java.io.FileOutputStream
 import java.io.IOException
 import java.nio.channels.Channels
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import kotlin.system.exitProcess
 
@@ -90,6 +91,10 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
 
     private val shutdownLatch = CountDownLatch(1)
 
+    // MediaCodec is driven from the encoder thread; control-socket commands are
+    // enqueued here and drained there so all codec access stays single-threaded.
+    private val codecCommands = ConcurrentLinkedQueue<() -> Unit>()
+
     private fun start() {
         try {
             // Register shutdown hook for graceful termination
@@ -147,38 +152,42 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
     // only channel that reaches this shell-uid process. Control is best-effort: if
     // the socket can't bind, streaming continues unaffected.
     private fun startControlServer(codec: MediaCodec) {
-        try {
-            JsonRpcSocketServer(CONTROL_SOCKET) { method, params ->
-                when (method) {
-                    "screencapture.setBitrate" -> {
-                        val bps = params?.optInt("bps", -1) ?: -1
-                        if (bps <= 0) {
-                            throw JsonRpcSocketServer.RpcException(
-                                JsonRpcSocketServer.ERROR_INTERNAL,
-                                "setBitrate requires a positive 'bps'",
-                            )
-                        }
-                        val clamped = bps.coerceIn(MIN_BITRATE, MAX_BITRATE)
+        JsonRpcSocketServer(CONTROL_SOCKET) { method, params ->
+            when (method) {
+                "screencapture.setBitrate" -> {
+                    val bps = params?.optInt("bps", -1) ?: -1
+                    if (bps <= 0) {
+                        throw JsonRpcSocketServer.RpcException(
+                            JsonRpcSocketServer.ERROR_INTERNAL,
+                            "setBitrate requires a positive 'bps'",
+                        )
+                    }
+                    val clamped = bps.coerceIn(MIN_BITRATE, MAX_BITRATE)
+                    // Apply on the encoder thread — never touch the codec from here.
+                    codecCommands.add {
                         codec.setParameters(Bundle().apply {
                             putInt(MediaCodec.PARAMETER_KEY_VIDEO_BITRATE, clamped)
                         })
                         Log.d(TAG, "Applied live bitrate: $clamped bps")
-                        JSONObject().put("bitrate", clamped)
                     }
-                    "screencapture.requestKeyFrame" -> {
+                    JSONObject().put("bitrate", clamped)
+                }
+                "screencapture.requestKeyFrame" -> {
+                    codecCommands.add {
                         codec.setParameters(Bundle().apply {
                             putInt(MediaCodec.PARAMETER_KEY_REQUEST_SYNC_FRAME, 0)
                         })
                         Log.d(TAG, "Requested immediate sync frame")
-                        JSONObject().put("ok", true)
                     }
-                    else -> throw JsonRpcSocketServer.RpcException(
-                        JsonRpcSocketServer.ERROR_METHOD_NOT_FOUND,
-                        "Method not found: $method",
-                    )
+                    JSONObject().put("ok", true)
                 }
-            }.startDaemon()
-        } catch (e: Exception) {
+                else -> throw JsonRpcSocketServer.RpcException(
+                    JsonRpcSocketServer.ERROR_METHOD_NOT_FOUND,
+                    "Method not found: $method",
+                )
+            }
+        }.startDaemon { e ->
+            // Bind runs on the daemon thread, so its failure surfaces here.
             Log.w(TAG, "Failed to start control server; live control unavailable", e)
         }
     }
@@ -312,6 +321,18 @@ class AvcServer(private val bitrate: Int, private val scale: Float, private val 
                 // Check if shutdown requested
                 if (shutdownLatch.count == 0L) {
                     break
+                }
+
+                // Apply pending control-socket commands on this (encoder) thread
+                // so every MediaCodec.setParameters call is serialized with encoding.
+                var command = codecCommands.poll()
+                while (command != null) {
+                    try {
+                        command()
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error applying codec command", e)
+                    }
+                    command = codecCommands.poll()
                 }
 
                 // Dequeue encoded output buffer

--- a/app/src/main/java/com/mobilenext/devicekit/JsonRpcSocketServer.kt
+++ b/app/src/main/java/com/mobilenext/devicekit/JsonRpcSocketServer.kt
@@ -26,10 +26,18 @@ class JsonRpcSocketServer(
 
         // JSON-RPC 2.0 standard error codes
         const val ERROR_PARSE = -32700
+        const val ERROR_INVALID_REQUEST = -32600
         const val ERROR_METHOD_NOT_FOUND = -32601
+        const val ERROR_INVALID_PARAMS = -32602
         const val ERROR_INTERNAL = -32603
 
         private const val CONTENT_LENGTH_PREFIX = "content-length:"
+
+        // Guardrails for a request on the local socket: a larger body is rejected
+        // before allocation, and a stalled peer can't pin the accept thread past
+        // the read timeout.
+        private const val MAX_CONTENT_LENGTH = 1 shl 20  // 1 MiB
+        private const val READ_TIMEOUT_MS = 5_000
     }
 
     // A dispatch handler throws RpcException to return a specific JSON-RPC error
@@ -67,12 +75,16 @@ class JsonRpcSocketServer(
     }
 
     // startDaemon runs start() on a daemon thread and returns immediately.
-    fun startDaemon(): Thread {
+    // onError, if given, receives any exception that ends start() on the daemon
+    // thread — including a bind failure, which happens on this thread rather than
+    // synchronously in the caller.
+    fun startDaemon(onError: ((Throwable) -> Unit)? = null): Thread {
         val thread = Thread {
             try {
                 start()
             } catch (e: Exception) {
-                Log.e(TAG, "server on $socketName stopped: ${e.message}")
+                if (onError != null) onError(e)
+                else Log.e(TAG, "server on $socketName stopped: ${e.message}")
             }
         }
         thread.isDaemon = true
@@ -90,6 +102,8 @@ class JsonRpcSocketServer(
     }
 
     private fun handleConnection(conn: LocalSocket) {
+        conn.soTimeout = READ_TIMEOUT_MS  // don't let a stalled peer pin the accept thread
+
         val reader = BufferedReader(InputStreamReader(conn.inputStream, StandardCharsets.ISO_8859_1))
 
         reader.readLine() ?: return // request line
@@ -103,6 +117,12 @@ class JsonRpcSocketServer(
             line = reader.readLine()
         }
 
+        if (contentLength < 0 || contentLength > MAX_CONTENT_LENGTH) {
+            Log.w(TAG, "Rejecting Content-Length $contentLength on $socketName")
+            writeResponse(conn, jsonRpcError(null, ERROR_INVALID_REQUEST, "Content-Length out of bounds"))
+            return
+        }
+
         val bodyChars = CharArray(contentLength)
         var offset = 0
         while (offset < contentLength) {
@@ -110,11 +130,27 @@ class JsonRpcSocketServer(
             if (n == -1) break
             offset += n
         }
+        if (offset < contentLength) {
+            Log.w(TAG, "Incomplete body: read $offset of $contentLength bytes on $socketName")
+            writeResponse(conn, jsonRpcError(null, ERROR_INVALID_REQUEST, "Incomplete request body"))
+            return
+        }
         val body = String(bodyChars, 0, offset)
 
-        val responseJson = handleJsonRpc(body)
-        val responseBytes = responseJson.toByteArray(StandardCharsets.UTF_8)
+        writeResponse(conn, handleJsonRpc(body))
+    }
 
+    // writeResponse frames a JSON-RPC reply as HTTP/1.1. A null body is a
+    // notification: acknowledged at the HTTP layer with no content.
+    private fun writeResponse(conn: LocalSocket, responseJson: String?) {
+        if (responseJson == null) {
+            conn.outputStream.write(
+                "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n".toByteArray(StandardCharsets.UTF_8)
+            )
+            conn.outputStream.flush()
+            return
+        }
+        val responseBytes = responseJson.toByteArray(StandardCharsets.UTF_8)
         val httpResponse = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" +
             "Content-Length: ${responseBytes.size}\r\nConnection: close\r\n\r\n"
         conn.outputStream.write(httpResponse.toByteArray(StandardCharsets.UTF_8))
@@ -122,7 +158,10 @@ class JsonRpcSocketServer(
         conn.outputStream.flush()
     }
 
-    private fun handleJsonRpc(body: String): String {
+    // handleJsonRpc returns the response body, or null for a notification (a
+    // request with no "id"), which is dispatched for its side effect but gets no
+    // JSON-RPC response.
+    private fun handleJsonRpc(body: String): String? {
         val request: JSONObject
         try {
             request = JSONObject(body)
@@ -131,16 +170,32 @@ class JsonRpcSocketServer(
             return jsonRpcError(null, ERROR_PARSE, "Parse error: ${e.message}")
         }
 
+        val isNotification = !request.has("id")
         val id = request.opt("id")
+
+        // Validate the envelope before dispatch: jsonrpc must be "2.0" and method
+        // must be a non-empty string.
+        val method = request.opt("method")
+        if (request.optString("jsonrpc") != JSONRPC_VERSION || method !is String || method.isEmpty()) {
+            return if (isNotification) null else jsonRpcError(id, ERROR_INVALID_REQUEST, "Invalid Request")
+        }
+
+        // params, when present, must be a JSON object — this API takes named
+        // params only, so arrays/scalars are rejected as invalid params.
+        val rawParams = request.opt("params")
+        if (rawParams != null && rawParams != JSONObject.NULL && rawParams !is JSONObject) {
+            return if (isNotification) null else jsonRpcError(id, ERROR_INVALID_PARAMS, "Invalid params")
+        }
+        val params = rawParams as? JSONObject
+
         return try {
-            val method = request.optString("method")
-            val params = request.optJSONObject("params")
-            jsonRpcResult(id, dispatch(method, params))
+            val result = dispatch(method, params)
+            if (isNotification) null else jsonRpcResult(id, result)
         } catch (e: RpcException) {
-            jsonRpcError(id, e.code, e.message)
+            if (isNotification) null else jsonRpcError(id, e.code, e.message)
         } catch (e: Exception) {
             Log.e(TAG, "Internal error", e)
-            jsonRpcError(id, ERROR_INTERNAL, "Internal error: ${e.message}")
+            if (isNotification) null else jsonRpcError(id, ERROR_INTERNAL, "Internal error: ${e.message}")
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add live AVC encoder control via a JSON-RPC socket so the host can change bitrate and request keyframes without restarting the stream. Also introduce a shared `JsonRpcSocketServer` and refactor `DeviceKitServer` to use it with safer I/O.

- **New Features**
  - `AvcServer`: new `localabstract:devicekit-avc` JSON-RPC channel; methods `screencapture.setBitrate(bps)` and `screencapture.requestKeyFrame`.
  - Commands are queued and applied on the encoder thread via `MediaCodec.setParameters`.
  - Clamp startup `--bitrate` and live updates to 100,000–10,000,000 bps. Access via `adb forward tcp:<port> localabstract:devicekit-avc` and a POST.

- **Refactors**
  - Added `JsonRpcSocketServer`: shared JSON-RPC 2.0 over one-shot HTTP framing.
  - Hardened I/O: 5s read timeout, 1 MiB Content-Length cap, short-read rejection, and strict envelope/params validation. Id-less requests are notifications (HTTP 204).
  - `startDaemon` now reports bind failures via `onError`; streaming continues if control cannot bind.

<sup>Written for commit 576771d3686843279f54cbf8b5abcd62030fee5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

