### PR TITLE
docs: changelog 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.4](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.4) (2026-07-13)
+* Feat: Live encoder control over a localabstract JSON-RPC socket — adjust bitrate and request keyframes without restarting the stream ([#38](https://github.com/mobile-next/devicekit-android/pull/38))
+* Fix: Hardened the JSON-RPC socket (read timeout, Content-Length cap, envelope validation) and serialized live encoder control onto the encoder thread ([#39](https://github.com/mobile-next/devicekit-android/pull/39))
+
+## [1.2.3](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.3) (2026-06-23)
+* Chore: Changed AVC bandwidth to 3Mbps with CBR (instead of VBR)
+
 ## [1.2.2](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.2) (2026-06-14)
 * Fix: Derive APK versionName/versionCode from the git tag at release time, so the published version matches the release tag
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added 1.2.4 and 1.2.3 entries to the changelog. 1.2.4 documents live encoder control via a localabstract JSON-RPC socket (bitrate adjustments, keyframe requests) and socket hardening; 1.2.3 notes the switch to AVC CBR at 3 Mbps.

<sup>Written for commit b728580dbdc76a1d962fa9bb92b28bae109d3228. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

