### PR TITLE
docs: changelog 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.5](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.5) (2026-08-10)
+* Feat: `device.io.keyboard.hide` — dismisses the soft keyboard via app_process by sending BACK when the IME window is shown ([#36](https://github.com/mobile-next/devicekit-android/pull/36))
+
 ## [1.2.4](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.4) (2026-07-13)
 * Feat: Live encoder control over a localabstract JSON-RPC socket — adjust bitrate and request keyframes without restarting the stream ([#38](https://github.com/mobile-next/devicekit-android/pull/38))
 * Fix: Hardened the JSON-RPC socket (read timeout, Content-Length cap, envelope validation) and serialized live encoder control onto the encoder thread ([#39](https://github.com/mobile-next/devicekit-android/pull/39))


### PR DESCRIPTION
## Summary
- Add 1.2.5 changelog entry for `device.io.keyboard.hide` (#36)

## Test plan
- N/A (docs only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the 1.2.5 changelog entry documenting `device.io.keyboard.hide`, which dismisses the soft keyboard by sending BACK when the IME is shown.

<sup>Written for commit 32bc557c01b26f68e674d283c747e24d65b06eff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

