### PR TITLE
chore: update changelog for 1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.6](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.6) (2026-08-24)
+* Fix: Align scaled capture dimensions to encoder alignment ([#42](https://github.com/mobile-next/devicekit-android/pull/42))
+
 ## [1.2.5](https://github.com/mobile-next/devicekit-android/releases/tag/1.2.5) (2026-08-10)
 * Feat: `device.io.keyboard.hide` — dismisses the soft keyboard via app_process by sending BACK when the IME window is shown ([#36](https://github.com/mobile-next/devicekit-android/pull/36))
 


### PR DESCRIPTION
## Summary

Prepare the 1.2.6 release by adding its CHANGELOG.md entry.

## Changes

* Added `## [1.2.6]` entry dated 2026-08-24 with the single change since 1.2.5:
  * Fix: Align scaled capture dimensions to encoder alignment (#42)

## Testing

Docs-only change; N/A.

## Related Issues

None

https://claude.ai/code/session_0179E686nxpjwfgR5Y4EatbR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the 1.2.6 entry to CHANGELOG to prepare the release. It documents the fix where scaled capture dimensions now align to encoder alignment; previously some scaled dimensions could violate encoder requirements.

- Review: Docs-only; verify the date (2026-08-24) and the 1.2.6 tag link. No code or behavior changes in this PR.

<sup>Written for commit 666aec84008da6fbe2a0e7f80744a82553768200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mobile-next/devicekit-android/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

